### PR TITLE
use dict headers for http request and response

### DIFF
--- a/libraries/Http.elm
+++ b/libraries/Http.elm
@@ -16,32 +16,49 @@ you have very strict latency requirements.
 
 import open Signal
 import Native.Http
+import Dict
 
-{-| The datatype for responses. Success contains only the returned message.
-Failures contain both an error code and an error message.
+type Headers = Dict.Dict String String
+
+{-| The datatype for responses. Success contains the returned message and the
+headers. Failures contain an error code, the message and the headers.
 -}
-data Response a = Success a | Waiting | Failure Int String
+data Response a = Success a Headers
+                | Waiting
+                | Failure Int String Headers
 
 type Request a = {
   verb : String,
   url  : String,
   body : a,
-  headers : [(String,String)]
+  headers : Headers
  }
 
 {-| Create a customized request. Arguments are request type (get, post, put,
 delete, etc.), target url, data, and a list of additional headers.
 -}
-request : String -> String -> String -> [(String,String)] -> Request String
+request : String -> String -> String -> Headers -> Request String
 request = Request
+
+{-| Helper method to create a request using a list instead of a dict for
+headers
+-}
+request' : String -> String -> String -> [(String,String)] -> Request String
+request' verb url body headers = Request verb url body (Dict.fromList headers)
+
+{-| Sets a header in the request. Adds it if it does not exists, replaces its
+value if it exists
+-}
+setHeader : (String, String) -> Request a -> Request a
+setHeader (header, value) request = { request | headers <- Dict.insert header value (request.headers) }
 
 {-| Create a GET request to the given url. -}
 get : String -> Request String
-get url = Request "GET" url "" []
+get url = Request "GET" url "" Dict.empty
 
 {-| Create a POST request to the given url, carrying the given data. -}
 post : String -> String -> Request String
-post url body = Request "POST" url body []
+post url body = Request "POST" url body Dict.empty
 
 {-| Performs an HTTP request with the given requests. Produces a signal
 that carries the responses.

--- a/libraries/Native/Signal/Http.js
+++ b/libraries/Native/Signal/Http.js
@@ -9,6 +9,8 @@ Elm.Native.Http.make = function(elm) {
   var JS = Elm.JavaScript.make(elm);
   var List = Elm.List.make(elm);
   var Signal = Elm.Signal.make(elm);
+  var Dict = Elm.Dict.make(elm);
+  var Utils = Elm.Native.Utils.make(elm);
 
 
   function registerReq(queue,responses) { return function(req) {
@@ -26,6 +28,27 @@ Elm.Native.Http.make = function(elm) {
     }
   }
 
+  // shamelessly copied from http://stackoverflow.com/a/19653587/1013628
+  function parseResponseHeaders(headerStr) {
+    var headers = [];
+    if (!headerStr) {
+      return headers;
+    }
+    var headerPairs = headerStr.split('\u000d\u000a');
+    for (var i = 0; i < headerPairs.length; i++) {
+      var headerPair = headerPairs[i];
+      // Can't use split() here because it does the wrong thing
+      // if the header value has the string ": " in it.
+      var index = headerPair.indexOf('\u003a\u0020');
+      if (index > 0) {
+        var key = JS.toString(headerPair.substring(0, index));
+        var val = JS.toString(headerPair.substring(index + 2));
+        headers.push(Utils.Tuple2(key, val));
+      }
+    }
+    return Dict.fromList(JS.toList(headers));
+  }
+
   function sendReq(queue,responses,req) {
     var response = { value: { ctor:'Waiting' } };
     queue.push(response);
@@ -36,8 +59,8 @@ Elm.Native.Http.make = function(elm) {
     request.onreadystatechange = function(e) {
       if (request.readyState === 4) {
         response.value = (request.status >= 200 && request.status < 300 ?
-        { ctor:'Success', _0:JS.toString(request.responseText) } :
-        { ctor:'Failure', _0:request.status, _1:JS.toString(request.statusText) });
+        { ctor:'Success', _0:JS.toString(request.responseText), _1:parseResponseHeaders(request.getAllResponseHeaders()) } :
+        { ctor:'Failure', _0:request.status, _1:JS.toString(request.statusText), _2:parseResponseHeaders(request.getAllResponseHeaders()) });
         setTimeout(function() { updateQueue(queue,responses); }, 0);
       }
     };
@@ -45,7 +68,7 @@ Elm.Native.Http.make = function(elm) {
     function setHeader(pair) {
       request.setRequestHeader( JS.fromString(pair._0), JS.fromString(pair._1) );
     }
-    List.map(setHeader)(req.headers);
+    List.map(setHeader)(Dict.toList(req.headers));
     request.send(JS.fromString(req.body));
   }
 

--- a/tests/test-files/good/Http.elm
+++ b/tests/test-files/good/Http.elm
@@ -1,0 +1,19 @@
+import Http
+
+makeUrl : String -> Http.Request String
+makeUrl tag =
+    let url = "http://api.flickr.com/services/rest/?format=json" ++
+        "&nojsoncallback=1&api_key=256663858aa10e52a838a58b7866d858" ++
+        "&method=flickr.photos.search&sort=random&per_page=10&tags="
+    in  Http.get (url ++ tag)
+
+pictures : Signal (Http.Response String)
+pictures = Http.send (constant (makeUrl "hello"))
+
+test : Http.Response String -> Bool
+test response = case response of
+    Http.Waiting -> True
+    Http.Failure code message headers -> False
+    Http.Success message headers -> True
+
+main = asText (foldp (&&) True (test <~ pictures))


### PR DESCRIPTION
Following [this discussion](https://groups.google.com/forum/#!topic/elm-discuss/9AOFt2j72H8), I added headers handling on the Response side of the Http library.

Furthermore, I used a dictionary instead of list of tuples for the headers. I think this is more suited for what one would one to do with headers: search for the value associate with a header.