### PR TITLE
Add slider to Graphics.Input

### DIFF
--- a/libraries/Graphics/Input.elm
+++ b/libraries/Graphics/Input.elm
@@ -23,7 +23,7 @@ examples in this library, so just read on to get a better idea of how it works!
 To learn about text fields, see the
 [`Graphics.Input.Field`](Graphics-Input-Field) library.
 
-@docs button, customButton, checkbox, dropDown
+@docs button, customButton, checkbox, dropDown, slider
 
 # Clicks and Hovers
 @docs clickable, hoverable
@@ -144,6 +144,10 @@ of 0.5 between -5 and 5, with default value 1:
 
       slideSlider : Signal Element
       slideSlider = slider slide.handle id -5 5 0.5 <~ slide.signal
+
+The first two `Float` arguments set the maximum and minimum values of the slider,
+respectively. The third `Float` argument sets the slider's step size, and the
+fourth `Float` argument sets the slider's value.
 -}
 slider : Handle a -> (Float -> a) -> Float -> Float -> Float -> Float -> Element
 slider = Native.Graphics.Input.slider

--- a/libraries/Graphics/Input.elm
+++ b/libraries/Graphics/Input.elm
@@ -136,6 +136,18 @@ will update to `Just Football`.
 dropDown : Handle a -> [(String,a)] -> Element
 dropDown = Native.Graphics.Input.dropDown
 
+{-| Create a range slider. The following slider lets you choose a multiple
+of 0.5 between -5 and 5, with default value 1:
+
+      slide : Input Float
+      slide = input 1
+
+      slideSlider : Signal Element
+      slideSlider = slider slide.handle id -5 5 0.5 <~ slide.signal
+-}
+slider : Handle a -> (Float -> a) -> Float -> Float -> Float -> Float -> Element
+slider = Native.Graphics.Input.slider
+
 {-| Detect mouse hovers over a specific `Element`. In the following example,
 we will create a hoverable picture called `cat`.
 

--- a/libraries/Native/Graphics/Input.js
+++ b/libraries/Native/Graphics/Input.js
@@ -64,6 +64,44 @@ Elm.Native.Graphics.Input.make = function(elm) {
         });
     }
 
+    function renderSlider(model) {
+        var node = newNode('input');
+        node.type = 'range';
+
+        node.min = model.min;
+        node.max = model.max;
+        node.step = model.step;
+        node.value = model.val;
+
+        node.style.display = 'block';
+        node.style.pointerEvents = 'auto';
+        node.elm_signal = model.signal;
+        node.elm_handler = model.handler;
+        node.addEventListener('input', function() {
+            elm.notify(node.elm_signal.id, node.elm_handler(node.value));
+        });
+        return node;
+    }
+
+    function updateSlider(node, oldModel, newModel) {
+        node.elm_signal = newModel.signal;
+        node.elm_handler = newModel.handler;
+        node.min = newModel.min;
+        node.max = newModel.max;
+        node.step = newModel.step;
+        node.value = newModel.val;
+    }
+
+    function slider(signal, handler, min, max, step, val) {
+        return A3(newElement, 100, 24, {
+            ctor: 'Custom',
+            type: 'Slider',
+            render: renderSlider,
+            update: updateSlider,
+            model: { signal:signal, handler:handler, min:min, max:max, step:step, val:val }
+        });
+    }
+
     function renderButton(model) {
         var node = newNode('button');
         node.style.display = 'block';
@@ -368,6 +406,7 @@ Elm.Native.Graphics.Input.make = function(elm) {
         customButton:F5(customButton),
         checkbox:F3(checkbox),
         dropDown:F2(dropDown),
+        slider:F6(slider),
         field:mkField('text'),
         email:mkField('email'),
         password:mkField('password'),


### PR DESCRIPTION
Not entirely sure how Input stuff works, so please correct me if I got anything wrong (esp. in Native).

Here is a somewhat more complicated test case where you can edit the upper bound of the slider live:

```haskell
import Graphics.Input as Input
import Graphics.Input.Field as Field
import String

ip = Input.input 0

mc : Input.Input Field.Content
mc = Input.input Field.noContent

field = Field.field Field.defaultStyle mc.handle id "Max" <~ mc.signal

s m v = let ma = 
          case String.toFloat m.string of
                    Just f -> f
                    Nothing -> 5
        in Input.slider ip.handle id -5 ma 0.5 v

main = (\x y z -> x `above` y `above` z)
     <~ field ~ (lift2 s mc.signal ip.signal) ~ lift asText ip.signal
```