### PR TITLE
Added support for links with the target attribute

### DIFF
--- a/libraries/Graphics/Element.elm
+++ b/libraries/Graphics/Element.elm
@@ -50,6 +50,7 @@ type Properties = {
   opacity : Float,
   color   : Maybe Color,
   href    : String,
+  target  : String,
   tag     : String,
   hover   : (),
   click   : ()
@@ -125,8 +126,15 @@ link : String -> Element -> Element
 link href e = let p = e.props in
               { element=e.element, props={p | href <- href} }
 
+{-| Create an `Element` that is a hyper-link with a target attribute. -}
+linkWithTarget : String -> String -> Element -> Element
+linkWithTarget href target e =
+    let p = e.props
+    in { element=e.element, props={p | href <- href
+                                     , target <- target} }
+
 newElement w h e =
-  { props = Properties (Native.Utils.guid ()) w h 1 Nothing "" "" () ()
+  { props = Properties (Native.Utils.guid ()) w h 1 Nothing "" "" "" () ()
   , element = e
   }
 

--- a/libraries/elm_dependencies.json
+++ b/libraries/elm_dependencies.json
@@ -1,9 +1,9 @@
-{ "version": "0.12.3"
+{ "version": "0.12.2"
 , "summary": "Elm's standard libraries"
 , "description": "The full set of standard libraries for Elm. This library is pegged to the version number of the compiler, so if you are using Elm 0.12.3, you should be using version 0.12.3 of the standard libraries."
 , "license": "BSD3"
 , "repository": "http://github.com/elm-lang/Elm.git"
-, "elm-version": "0.12.3"
+, "elm-version": "0.12.2"
 , "dependencies": {}
 , "exposed-modules":
     [ "Array"

--- a/runtime/Render/Element.js
+++ b/runtime/Render/Element.js
@@ -24,6 +24,7 @@ function setProps(elem, e) {
     if (props.href !== '') {
         var a = newElement('a');
         a.href = props.href;
+        a.target = props.target;
         a.style.width = '100%';
         a.style.height = '100%';
         a.style.top = 0;


### PR DESCRIPTION
I added a small feature that allows a target attribute on link tags.

An example:

```haskell
main : Element                                                                    
main = flow down                                                                  
        [ linkWithTarget "http://google.com" "_blank" <| plainText "Link With Target"
        , link "http://google.com" <| plainText "Link without target"             
        ]  
```

The top link when clicked will open a new tab or window, depending on the browser to google, while the bottom one will change the current page to google.

