### PR TITLE
Fix the path to search for test files

### DIFF
--- a/tests/Test/Compiler.hs
+++ b/tests/Test/Compiler.hs
@@ -39,7 +39,7 @@ getElms filePath =
 
 testsDir :: FilePath
 testsDir =
-    "tests" </> "compiler" </> "test-files"
+    "tests" </> "test-files"
 
 
 -- RUN COMPILER


### PR DESCRIPTION
None of the compiler tests were running because the testsDir was incorrect.  Note that after fixing this, there are several failing tests.