### PR TITLE
In port conversion, wrap record fields in strings to prevent bad obfuscation.

### DIFF
--- a/src/Generate/JavaScript/Helpers.hs
+++ b/src/Generate/JavaScript/Helpers.hs
@@ -42,6 +42,11 @@ prop name =
     PropId () (var name)
 
 
+propBracketRef :: Expression () -> String -> Expression ()
+propBracketRef expr prop =
+    BracketRef () expr (StringLit () prop)
+
+
 string = StringLit ()
 
 

--- a/src/Generate/JavaScript/Ports.hs
+++ b/src/Generate/JavaScript/Ports.hs
@@ -127,7 +127,7 @@ inc tipe x =
           where
             object = ObjectLit () $ (prop "_", ObjectLit () []) : keys
             keys = map convert fields
-            convert (f,t) = (prop f, inc t (DotRef () x (var f)))
+            convert (f,t) = (prop f, inc t (propBracketRef x f))
 
 
 incomingTuple :: [CanonicalType] -> Expression () -> Expression ()
@@ -214,4 +214,4 @@ out tipe x =
           ObjectLit () keys
           where
             keys = map convert fields
-            convert (f,t) = (PropId () (var f), out t (DotRef () x (var f)))
+            convert (f,t) = (PropString () f, out t (DotRef () x (var f)))


### PR DESCRIPTION
With this test file:
```elm
type alias Rec = { abc: Int, efg: Int }

port testOutPort : Rec
port testOutPort = { abc = 1, efg = 2 }   

port testInPort : Rec
```

It makes this diff in output:
```diff
--- test.js	2015-01-10 22:45:22.000000000 +0100
+++ test2.js	2015-01-10 22:59:20.000000000 +0100
@@ -425,16 +425,16 @@
    var testInPort = _P.portIn("testInPort",
    function (v) {
       return typeof v === "object" && "abc" in v && "efg" in v ? {_: {}
-                                                                 ,abc: typeof v.abc === "number" ? v.abc : _U.badPort("a number",
-                                                                 v.abc)
-                                                                 ,efg: typeof v.efg === "number" ? v.efg : _U.badPort("a number",
-                                                                 v.efg)} : _U.badPort("an object with fields \'abc\', \'efg\'",
+                                                                 ,abc: typeof v["abc"] === "number" ? v["abc"] : _U.badPort("a number",
+                                                                 v["abc"])
+                                                                 ,efg: typeof v["efg"] === "number" ? v["efg"] : _U.badPort("a number",
+                                                                 v["efg"])} : _U.badPort("an object with fields \'abc\', \'efg\'",
       v);
    });
    var testOutPort = _P.portOut("testOutPort",
    function (v) {
-      return {abc: v.abc
-             ,efg: v.efg};
+      return {"abc": v.abc
+             ,"efg": v.efg};
    },
    {_: {},abc: 1,efg: 2});
    var Rec = F2(function (a,b) {
```