### PR TITLE
Expose modules even with obfuscation (ie. Elm['Main'] = {})

### DIFF
--- a/src/Generate/JavaScript.hs
+++ b/src/Generate/JavaScript.hs
@@ -316,7 +316,7 @@ flattenLets defs lexpr@(A _ expr) =
 
 generate :: CanonicalModule -> String 
 generate modul =
-    show . prettyPrint $ setup "Elm" (names ++ ["make"]) ++
+    show . prettyPrint $ setup withExposedNamespaceInit "Elm" (names ++ ["make"]) ++
              [ assign ("Elm" : names ++ ["make"]) (function [localRuntime] programStmts) ]
   where
     names :: [String]
@@ -329,7 +329,7 @@ generate modul =
     programStmts =
         concat
         [ [ ExprStmt () (string "use strict") ]
-        , setup localRuntime (names ++ ["values"])
+        , setup withNamespaceInit localRuntime (names ++ ["values"])
         , [ IfSingleStmt () thisModule (ret thisModule) ]
         , [ VarDeclStmt () localVars ]
         , body
@@ -356,9 +356,17 @@ generate modul =
       where
         defs = mapM definition . fst . flattenLets [] $ Module.program (Module.body modul)
 
-    setup namespace path = map create paths
+    withNamespaceInit path = (InfixExpr () OpLOr (obj path) (ObjectLit () []))
+
+    withExposedNamespaceInit path =
+        AssignExpr () OpAssign exposedNs (withNamespaceInit path)
       where
-        create name = assign name (InfixExpr () OpLOr (obj name) (ObjectLit () []))
+          exposedNs = (LBracket () (bracketObj (init path)) (StringLit () (last path)))
+
+
+    setup makeRhs namespace path = map create paths
+      where
+        create name = assign name (makeRhs name)
         paths = drop 2 . init . List.inits $ namespace : path
 
     jsExports = assign (localRuntime : names ++ ["values"]) (ObjectLit () exs)

--- a/src/Generate/JavaScript/Helpers.hs
+++ b/src/Generate/JavaScript/Helpers.hs
@@ -51,6 +51,12 @@ obj vars =
       x:xs -> foldl (DotRef ()) (ref x) (map var xs)
       [] -> error "dotSep must be called on a non-empty list of variables"
 
+bracketObj :: [String] -> Expression ()
+bracketObj vars =
+    case vars of
+      x:xs -> foldl (BracketRef ()) (ref x) (map (StringLit ()) xs)
+      [] -> error "bracketObj must be called on a non-empty list of variables"
+
 
 -- Specific Utilities
 


### PR DESCRIPTION
With this test file:
```elm
type alias Rec = { abc: Int, efg: Int }

port testOutPort : Rec
port testOutPort = { abc = 1, efg = 2 }   

port testInPort : Rec
```

This PR creates this diff:
```diff
--- test.js	2015-01-11 09:56:01.000000000 +0100
+++ test3.js	2015-01-11 10:29:20.000000000 +0100
@@ -1,5 +1,5 @@
var Elm = Elm || { Native: {} };
-Elm.Basics = Elm.Basics || {};
+Elm.Basics = Elm["Basics"] = Elm.Basics || {};
 Elm.Basics.make = function (_elm) {
    "use strict";
    _elm.Basics = _elm.Basics || {};
@@ -178,7 +178,7 @@
                         ,uncurry: uncurry};
    return _elm.Basics.values;
 };
-Elm.List = Elm.List || {};
+Elm.List = Elm["List"] = Elm.List || {};
 Elm.List.make = function (_elm) {
    "use strict";
    _elm.List = _elm.List || {};
@@ -410,7 +410,7 @@
                       ,sortWith: sortWith};
    return _elm.List.values;
 };
-Elm.Main = Elm.Main || {};
+Elm.Main = Elm["Main"] = Elm.Main || {};
 Elm.Main.make = function (_elm) {
    "use strict";
    _elm.Main = _elm.Main || {};
@@ -444,7 +444,7 @@
                       ,Rec: Rec};
    return _elm.Main.values;
 };
-Elm.Maybe = Elm.Maybe || {};
+Elm.Maybe = Elm["Maybe"] = Elm.Maybe || {};
 Elm.Maybe.make = function (_elm) {
    "use strict";
    _elm.Maybe = _elm.Maybe || {};
@@ -2305,7 +2305,7 @@
     };
 };
 
-Elm.Result = Elm.Result || {};
+Elm.Result = Elm["Result"] = Elm.Result || {};
 Elm.Result.make = function (_elm) {
    "use strict";
    _elm.Result = _elm.Result || {};
@@ -2550,7 +2550,7 @@
                         ,fromMaybe: fromMaybe};
    return _elm.Result.values;
 };
-Elm.Signal = Elm.Signal || {};
+Elm.Signal = Elm["Signal"] = Elm.Signal || {};
 Elm.Signal.make = function (_elm) {
    "use strict";
    _elm.Signal = _elm.Signal || {};

```

It is not necessary to expose & preserve the names of all the core modules, but there is no way to tell between core and user-defined ones.