### PR TITLE
Fix pretty printing of cons

### DIFF
--- a/src/AST/Expression/General.hs
+++ b/src/AST/Expression/General.hs
@@ -224,7 +224,7 @@ prettyParens (Annotation.A _ expr) =
   where
     needed =
       case expr of
-        Binop _ _ _ -> True
+        Binop name _ _ -> not ((Var.toString name) == "::")
         Lambda _ _  -> True
         App _ _     -> True
         MultiIf _   -> True


### PR DESCRIPTION
Right now, cons expressions don't pretty print correctly due to incorrect parentheses. This is because the special check for :: is being done in Data expressions, when cons is being parsed as a BinOp.

This fix adds the check to the binOp case of the parentheses function.