### PR TITLE
Fix to reflect renamed type for JavaScript values through ports

### DIFF
--- a/src/AST/Variable.hs
+++ b/src/AST/Variable.hs
@@ -61,9 +61,9 @@ is home name var =
     var == Canonical (Module home) name
 
 
-isJson :: Canonical -> Bool
-isJson =
-    is ["Json", "Encode"] "Value"
+isJSValue :: Canonical -> Bool
+isJSValue =
+    is ["JavaScript", "Encode"] "Value"
 
 
 isMaybe :: Canonical -> Bool

--- a/src/Generate/JavaScript/Port.hs
+++ b/src/Generate/JavaScript/Port.hs
@@ -111,7 +111,7 @@ toType tipe x =
             from checks = check x checks x
 
       Type name
-          | Var.isJson name ->
+          | Var.isJSValue name ->
               x
 
           | Var.isTuple name ->
@@ -212,7 +212,7 @@ fromType tipe x =
               x
 
       Type name
-          | Var.isJson name -> x
+          | Var.isJSValue name -> x
           | Var.isTuple name -> ArrayLit () []
           | otherwise -> error "bad type got to an output"
 

--- a/src/Transform/Canonicalize/Port.hs
+++ b/src/Transform/Canonicalize/Port.hs
@@ -84,7 +84,7 @@ validForeignType name portKind rootType tipe =
           valid (T.dealias args t)
 
       T.Type v ->
-          case any ($ v) [ Var.isJson, Var.isPrimitive, Var.isTuple ] of
+          case any ($ v) [ Var.isJSValue, Var.isPrimitive, Var.isTuple ] of
             True -> return ()
             False -> err "It contains an unsupported type"
 


### PR DESCRIPTION
Core module _Json.Encode_ is renamed to _JavaScript.Encode_

So the test for JavaScript values going through ports must be against type `JavaScript.Encode.Value`

Also renamed the test function itself to reflect its meaning more closely.