### PR TITLE
-Werror -> -Wall

### DIFF
--- a/elm-compiler.cabal
+++ b/elm-compiler.cabal
@@ -33,7 +33,7 @@ source-repository head
 
 Library
     ghc-options:
-        -threaded -O2 -W -Werror
+        -threaded -O2 -W -Wall
 
     Hs-Source-Dirs:
         src


### PR DESCRIPTION
With more recent versions of transformers, ErrorT is deprecated so this
is causing build failures.

Wall will still print all of the same errors but won't stop installation
from working.