### PR TITLE
Update helper functions in Test.Compiler to fit new version of Compiler.compile.

### DIFF
--- a/elm-compiler.cabal
+++ b/elm-compiler.cabal
@@ -218,5 +218,6 @@ Test-Suite compiler-tests
         text >= 1 && < 2,
         transformers >= 0.2 && < 0.5,
         union-find >= 0.2 && < 0.3,
-        unordered-containers >= 0.1 && < 0.3
+        unordered-containers >= 0.1 && < 0.3,
+        bifunctors >= 4.2.1
 

--- a/elm-compiler.cabal
+++ b/elm-compiler.cabal
@@ -186,7 +186,7 @@ Test-Suite compiler-tests
         Test.Property.Arbitrary
         AST.Helpers
         AST.Literal
-        AST.PrettyPrint
+        Reporting.PrettyPrint
 
     build-depends:
         test-framework > 0.8 && < 0.9,

--- a/tests/Test/Property.hs
+++ b/tests/Test/Property.hs
@@ -12,7 +12,7 @@ import Text.PrettyPrint as P
 import AST.Literal as Lit
 import qualified AST.Pattern as P
 import qualified AST.Variable as V
-import AST.PrettyPrint (Pretty, pretty)
+import Reporting.PrettyPrint (Pretty, pretty)
 import Parse.Helpers (IParser, iParse)
 import Parse.Literal (literal)
 import qualified Parse.Pattern as Pat (expr)


### PR DESCRIPTION
In particular, this PR accomodates the following changes to Compiler.compile:
* New parameter isRoot :: Bool (introduced in [fb1a6d26f0](https://github.com/elm-lang/elm-compiler/blob/fb1a6d26f09f3e43fc45df9df82ec548bbb276e7/src/Elm/Compiler.hs))
* Return value of type `([Warning], Either [Error] (PublicModule.Interface, String))`, rather than `Either String (PublicModule.Interface, String)`.

Note: This fixes `Test.Compiler`, but not `Test.Property`.  I got the tests to run by:

1. Removing `Test.Property` and `Test.Property.Arbitrary` from elm-compiler.cabal.
2. Removing `import Test.Property` and the reference to `propertyTests` in [`Test.hs`](https://github.com/manleyjster/elm-compiler/blob/fix-compiler-tests/tests/Test.hs#L13).

Running `cabal test` then results in all of the tests passing except for two involving ports:
* [`PortsWithTypeAliases.elm`](https://github.com/manleyjster/elm-compiler/blob/fix-compiler-tests/tests/test-files/good/PortsWithTypeAliases.elm)
* [`Ports.elm`](https://github.com/manleyjster/elm-compiler/blob/fix-compiler-tests/tests/test-files/good/Ports.elm)

Both of these tests fail with syntax errors - maybe the source files haven't been updated for version 0.15?

