### PR TITLE
Improved parse error messages

### DIFF
--- a/src/Parse/Helpers.hs
+++ b/src/Parse/Helpers.hs
@@ -68,12 +68,12 @@ var =
 
 lowVar :: IParser String
 lowVar =
-  makeVar lower <?> "a lower case variable"
+  makeVar lower <?> "a lower case name"
 
 
 capVar :: IParser String
 capVar =
-  makeVar upper <?> "an upper case variable"
+  makeVar upper <?> "an upper case name"
 
 
 qualifiedVar :: IParser String
@@ -88,7 +88,7 @@ rLabel = lowVar
 
 innerVarChar :: IParser Char
 innerVarChar =
-  alphaNum <|> char '_' <|> char '\'' <?> "more letters in this variable"
+  alphaNum <|> char '_' <|> char '\'' <?> "more letters in this name"
 
 
 makeVar :: IParser Char -> IParser String

--- a/src/Parse/Helpers.hs
+++ b/src/Parse/Helpers.hs
@@ -63,7 +63,7 @@ iParseWithTable sourceName table aParser input =
 
 var :: IParser String
 var =
-  makeVar (letter <|> char '_') <?> "a variable"
+  makeVar (letter <|> char '_') <?> "a name"
 
 
 lowVar :: IParser String

--- a/src/Parse/Module.hs
+++ b/src/Parse/Module.hs
@@ -78,7 +78,7 @@ import' =
 
 listing :: IParser a -> IParser (Var.Listing a)
 listing item =
-  expecting "a listing of values to expose, like (..)" $
+  expecting "a listing of values and types to expose, like (..)" $
   do  try (whitespace >> char '(')
       whitespace
       listing <-
@@ -93,7 +93,7 @@ listing item =
 
 value :: IParser Var.Value
 value =
-    val <|> tipe <?> "a value to expose"
+    val <|> tipe <?> "a value or type to expose"
   where
     val =
       Var.Value <$> (lowVar <|> parens symOp)


### PR DESCRIPTION
Previously, e.g., on a parse error for a record label, the parser would complain it expected a `lower case variable`, which might confuse the programmer. (Why is a record label a "variable"? It should be a "name".) Similarly, in the parse error for `case ... of Module.lowercasename -> ...` the parser would complain it expected an `upper case variable`, which again is confusing (see https://github.com/elm-lang/elm-compiler/issues/948). Instead, it would make more sense to complain that an `upper case name` was expected (a constructor is not a "variable", but it is a "name").