### PR TITLE
Fix a missing space

### DIFF
--- a/src/Reporting/Error/Canonicalize.hs
+++ b/src/Reporting/Error/Canonicalize.hs
@@ -238,7 +238,7 @@ argMismatchReport kind var expected actual =
     preHint =
       kind ++ " " ++ Var.toString var ++ " has too "
       ++ (if actual < expected then "few" else "many")
-      ++ "arguments."
+      ++ " arguments."
 
     postHint =
       "Expecting " ++ show expected ++ ", but got " ++ show actual ++ "."


### PR DESCRIPTION
**Before:**

```
Type Shrink.Shrinker has too fewarguments.
```

**After:**

```
Type Shrink.Shrinker has too few arguments.
```