### PR TITLE
Use backticks instead of single quotes for reporting code terms

### DIFF
--- a/src/CommandLineRouter.hs
+++ b/src/CommandLineRouter.hs
@@ -26,10 +26,10 @@ attemptToRun command args =
       case found of
         Nothing ->
           hPutStrLn stderr $
-            "Could not find command '" ++ command ++ "'. Maybe there is a typo?\n\n\
+            "Could not find command `" ++ command ++ "`. Maybe there is a typo?\n\n\
             \Default commands include:\n\n"
             ++ availableCommands ++
-            "\nWhen you try to run the command '" ++ command ++ "' we actually search for an\n\
+            "\nWhen you try to run the command `" ++ command ++ "` we actually search for an\n\
             \  executable named elm-" ++ command ++ ". Are you able to run elm-" ++ command ++ "?\n\
             \  Is it on your PATH?"
 

--- a/src/Elm/Utils.hs
+++ b/src/Elm/Utils.hs
@@ -87,7 +87,7 @@ unwrappedRun command args =
 missingExe :: String -> CommandError
 missingExe command =
   MissingExe $
-    "Could not find command '" ++ command ++ "'. Do you have it installed?\n\
+    "Could not find command `" ++ command ++ "`. Do you have it installed?\n\
     \    Can it be run from anywhere? Is it on your PATH?"
 
 

--- a/src/Generate/Cases.hs
+++ b/src/Generate/Cases.hs
@@ -258,5 +258,5 @@ matchMix vs branches def =
 
 noMatch :: String -> a
 noMatch name =
-    error $ "unexpected pattern in '" ++ name ++
-            "' function. Report a compiler issue to <https://github.com/elm-lang/Elm>."
+    error $ "unexpected pattern in `" ++ name ++
+            "` function. Report a compiler issue to <https://github.com/elm-lang/Elm>."

--- a/src/Generate/JavaScript/Port.hs
+++ b/src/Generate/JavaScript/Port.hs
@@ -41,7 +41,7 @@ typeToString tipe =
     JSString -> "a string"
     JSArray -> "an array"
     JSObject fields ->
-      "an object with fields '" ++ List.intercalate "', '" fields ++ "'"
+      "an object with fields `" ++ List.intercalate "`, `" fields ++ "`"
 
 
 _Array :: String -> Expression ()

--- a/src/Parse/Helpers.hs
+++ b/src/Parse/Helpers.hs
@@ -101,7 +101,7 @@ makeVar firstChar =
 
 reserved :: String -> IParser String
 reserved word =
-  expecting ("reserved word '" ++ word ++ "'") $
+  expecting ("reserved word `" ++ word ++ "`") $
     do  string word
         notFollowedBy innerVarChar
         return word

--- a/src/Parse/Module.hs
+++ b/src/Parse/Module.hs
@@ -67,7 +67,7 @@ import' =
     as' moduleName =
       do  try (whitespace >> reserved "as")
           whitespace
-          capVar <?> ("an alias for module '" ++ moduleName ++ "'")
+          capVar <?> ("an alias for module `" ++ moduleName ++ "`")
 
     exposing :: IParser (Var.Listing Var.Value)
     exposing =

--- a/src/Reporting/Error/Canonicalize.hs
+++ b/src/Reporting/Error/Canonicalize.hs
@@ -139,7 +139,7 @@ toReport :: P.Dealiaser -> Error -> Report.Report
 toReport dealiaser err =
   case err of
     Var (VarError kind name problem suggestions) ->
-        let var = kind ++ " '" ++ name ++ "'"
+        let var = kind ++ " `" ++ name ++ "`"
         in
         case problem of
           Ambiguous ->
@@ -149,12 +149,12 @@ toReport dealiaser err =
 
           UnknownQualifier qualifier ->
               namingError
-                ("Cannot find " ++ var ++ ", qualifier '" ++ qualifier ++ "' is not in scope.")
+                ("Cannot find " ++ var ++ ", qualifier `" ++ qualifier ++ "` is not in scope.")
                 (maybeYouWant suggestions)
 
           QualifiedUnknown qualifier ->
               namingError
-                ("Cannot find " ++ var ++ ", module '" ++ qualifier ++ "' does not expose that value.")
+                ("Cannot find " ++ var ++ ", module `" ++ qualifier ++ "` does not expose that value.")
                 (maybeYouWant suggestions)
 
           ExposedUnknown ->
@@ -200,17 +200,17 @@ toReport dealiaser err =
         case importError of
           ModuleNotFound suggestions ->
               namingError
-                ("Could not find a module named '" ++ moduleName ++ "'")
+                ("Could not find a module named `" ++ moduleName ++ "`")
                 (maybeYouWant (map Module.nameToString suggestions))
 
           ValueNotFound value suggestions ->
               namingError
-                ("Module '" ++ moduleName ++ "' does not expose '" ++ value ++ "'")
+                ("Module `" ++ moduleName ++ "` does not expose `" ++ value ++ "`")
                 (maybeYouWant suggestions)
 
     Export name suggestions ->
         namingError
-          ("Could not export '" ++ name ++ "' which is not defined in this module.")
+          ("Could not export `" ++ name ++ "` which is not defined in this module.")
           (maybeYouWant suggestions)
 
     Port (PortError name isInbound _rootType localType maybeMessage) ->
@@ -220,7 +220,7 @@ toReport dealiaser err =
 
           preHint =
             "Trying to send " ++ maybe "an unsupported type" id maybeMessage
-            ++ " through " ++ boundPort ++ " '" ++ name ++ "'"
+            ++ " through " ++ boundPort ++ " `" ++ name ++ "`"
 
           postHint =
             "The specific unsupported type is:\n\n"

--- a/src/Reporting/Error/Syntax.hs
+++ b/src/Reporting/Error/Syntax.hs
@@ -50,7 +50,7 @@ toReport dealiaser err =
     TypeWithoutDefinition valueName ->
         Report.simple
           "MISSING DEFINITION"
-          ("There is a type annotation for '" ++ valueName ++ "' but there"
+          ("There is a type annotation for `" ++ valueName ++ "` but there"
             ++ "is no corresponding definition!"
           )
           ("Directly below the type annotation, put a definition like:\n\n"
@@ -60,7 +60,7 @@ toReport dealiaser err =
     PortWithoutAnnotation portName ->
         Report.simple
           "PORT ERROR"
-          ("Port '" ++ portName ++ "' does not have a type annotation!")
+          ("Port `" ++ portName ++ "` does not have a type annotation!")
           ("Directly above the port definition, I need something like this:\n\n"
             ++ "    port " ++ portName ++ " : Signal Int"
           )
@@ -78,30 +78,30 @@ toReport dealiaser err =
     DuplicateValueDeclaration name ->
         Report.simple
           "DUPLICATE DEFINITION"
-          ("Naming multiple top-level values '" ++ name ++ "' makes things\n"
-            ++ "ambiguous. When you say '" ++ name ++ "' which one do you want?"
+          ("Naming multiple top-level values `" ++ name ++ "` makes things\n"
+            ++ "ambiguous. When you say `" ++ name ++ "` which one do you want?"
           )
-          ("Find all the top-level values named '" ++ name ++ "' and\n"
+          ("Find all the top-level values named `" ++ name ++ "` and\n"
             ++ "do some renaming. Make sure the names are distinct!"
           )
 
     DuplicateTypeDeclaration name ->
         Report.simple
           "DUPLICATE DEFINITION"
-          ("Naming multiple types '" ++ name ++ "' makes things ambiguous\n"
-            ++ "When you say '" ++ name ++ "' which one do you want?"
+          ("Naming multiple types `" ++ name ++ "` makes things ambiguous\n"
+            ++ "When you say `" ++ name ++ "` which one do you want?"
           )
-          ("Find all the types named '" ++ name ++ "' and\n"
+          ("Find all the types named `" ++ name ++ "` and\n"
             ++ "do some renaming. Make sure the names are distinct!"
           )
 
     DuplicateDefinition name ->
         Report.simple
           "DUPLICATE DEFINITION"
-          ("Naming multiple values '" ++ name ++ "' in a single let-expression makes\n"
-            ++ "things ambiguous. When you say '" ++ name ++ "' which one do you want?"
+          ("Naming multiple values `" ++ name ++ "` in a single let-expression makes\n"
+            ++ "things ambiguous. When you say `" ++ name ++ "` which one do you want?"
           )
-          ("Find all the values named '" ++ name ++ "' in this let-expression and\n"
+          ("Find all the values named `" ++ name ++ "` in this let-expression and\n"
             ++ "do some renaming. Make sure the names are distinct!"
           )
 
@@ -135,13 +135,13 @@ unboundTypeVars :: String -> String -> [String] -> String -> Report.Report
 unboundTypeVars typeName tvar tvars revisedDeclaration =
   Report.simple
     "UNBOUND TYPE VARS"
-    ( "Not all type variables in '" ++ typeName ++ "' are listed, making sneaky\n"
+    ( "Not all type variables in `" ++ typeName ++ "` are listed, making sneaky\n"
       ++ "type errors possible. Unbound type variables include: "
       ++ List.intercalate ", " (tvar:tvars)
     )
     ( "You probably want this definition instead:\n"
       ++ concatMap ("\n    "++) (lines revisedDeclaration) ++ "\n\n"
-      ++ "Here's why. Imagine one '" ++ typeName ++ "' where '" ++ tvar ++ "' is an Int and\n"
+      ++ "Here's why. Imagine one `" ++ typeName ++ "` where `" ++ tvar ++ "` is an Int and\n"
       ++ "another where it is a Bool. When we explicitly list the type variables, type\n"
       ++ "checker can see that they are actually different types."
     )
@@ -202,7 +202,7 @@ parseErrorReport messages =
         [msg] ->
             case unkeyword msg of
               Just kwd ->
-                  "It looks like the keyword '" ++ kwd ++ "' is being used as a variable.\n"
+                  "It looks like the keyword `" ++ kwd ++ "` is being used as a variable.\n"
                   ++ "Try renaming it to something else."
               Nothing ->
                   msg

--- a/src/Reporting/Error/Type.hs
+++ b/src/Reporting/Error/Type.hs
@@ -90,14 +90,14 @@ toReport dealiaser err =
             P.pretty dealiaser False tipe
         in
         Report.simple "INFINITE TYPE"
-          ( "I am inferring weird self-referential type for '" ++ name ++ "'"
+          ( "I am inferring weird self-referential type for `" ++ name ++ "`"
           )
           ( "The bit of the type that is self-referential looks like this:\n\n"
             ++ P.render (P.nest 4 (prettyVar <+> P.equals <+> prettyType))
-            ++ "\n\nThe cause is often that the usage of '" ++ name ++ "' is flipped around.\n\n"
+            ++ "\n\nThe cause is often that the usage of `" ++ name ++ "` is flipped around.\n\n"
             ++ "Maybe you are inserting a data structure into an element? Maybe you are giving\n"
             ++ "a function to an argument? Either way, something is probably backwards!\n\n"
-            ++ "Try breaking the code related to '" ++ name ++ "' into smaller pieces.\n"
+            ++ "Try breaking the code related to `" ++ name ++ "` into smaller pieces.\n"
             ++ "Give each piece a name and try to write down its type."
           )
 
@@ -190,7 +190,7 @@ hintToString hint =
 
     BadTypeAnnotation name ->
         ( Nothing
-        , "The type annotation for '" ++ name ++ "' does not match its definition."
+        , "The type annotation for `" ++ name ++ "` does not match its definition."
         )
 
 

--- a/src/Reporting/Warning.hs
+++ b/src/Reporting/Warning.hs
@@ -39,13 +39,13 @@ toReport dealiaser warning =
     UnusedImport moduleName ->
         Report.simple
           "unused import"
-          ("Module '" ++ Module.nameToString moduleName ++ "' is unused.")
+          ("Module `" ++ Module.nameToString moduleName ++ "` is unused.")
           ""
 
     MissingTypeAnnotation name inferredType ->
         Report.simple
           "missing type annotation"
-          ("Top-level value '" ++ name ++ "' does not have a type annotation.")
+          ("Top-level value `" ++ name ++ "` does not have a type annotation.")
           ( "The type annotation you want looks something like this:\n\n"
             ++ P.render (P.nest 4 typeDoc)
           )

--- a/src/Type/Environment.hs
+++ b/src/Type/Environment.hs
@@ -117,7 +117,7 @@ get :: Environment -> (Environment -> Map.Map String a) -> String -> a
 get env subDict key =
     Map.findWithDefault (error msg) key (subDict env)
   where
-    msg = "Could not find type constructor '" ++ key ++ "' while checking types."
+    msg = "Could not find type constructor `" ++ key ++ "` while checking types."
 
 
 freshDataScheme
@@ -210,8 +210,8 @@ instantiatorHelp env aliasVars sourceType =
             Just t  -> return t
             Nothing ->
                 error $
-                  "Could not find type constructor '" ++
-                  V.toString name ++ "' while checking types."
+                  "Could not find type constructor `" ++
+                  V.toString name ++ "` while checking types."
 
       T.App t ts ->
           do  t'  <- go t

--- a/src/Type/Solve.hs
+++ b/src/Type/Solve.hs
@@ -167,7 +167,7 @@ actuallySolve constraint =
                   Nothing ->
                       if List.isPrefixOf "Native." name
                         then liftIO (variable Flexible)
-                        else error ("Could not find '" ++ name ++ "' when solving type constraints.")
+                        else error ("Could not find `" ++ name ++ "` when solving type constraints.")
 
             t <- TS.flatten term
             unify Error.None region freshCopy t

--- a/src/Type/Unify.hs
+++ b/src/Type/Unify.hs
@@ -167,7 +167,7 @@ actuallyUnify variable1 variable2 = do
           let v = render (pretty Never var)
           in
           typeError variable1 variable2 $ Error.PreNote $
-            "Could not unify rigid type variable '" ++ v ++ "'. The problem probably\n"
+            "Could not unify rigid type variable `" ++ v ++ "`. The problem probably\n"
             ++ "relates to the type variable being shared between two type annotations.\n"
             ++ "Try commenting out some type annotations and see what happens."
 
@@ -356,7 +356,7 @@ fieldMismatchError missingFields =
     case Map.keys missingFields of
       [] -> ""
       [key] ->
-        "Looks like a record is missing the field '" ++ key ++ "'"
+        "Looks like a record is missing the field `" ++ key ++ "`"
       keys ->
         "Looks like a record is missing fields "
         ++ List.intercalate ", " (init keys) ++ ", and " ++ last keys


### PR DESCRIPTION
The motivation behind this PR was that I ran into this error:

```
Could not find variable 'makeSection''.

Close matches include:
    makeSection
```

At first I ran off to figure out why `makeSection` was not in scope, then eventually came back and realized it was actually complaining about a variable called `makeSection'`. I missed it because of the single quotes around the variable name.

This PR changes such usages to backticks instead, like so:

```
Could not find variable `makeSection'`.

Close matches include:
    makeSection
```

Arguments for this change:

* Single quotes are often used at the end of variable names, so the current collision will come up often.
* Backticks are not allowed in variable names, so there is no potential for such a collision there.
* Backticks are used in Markdown to denote code snippets, which is also what they do in these cases.