### PR TITLE
Relax bounds on blaze-... libraries

### DIFF
--- a/elm-compiler.cabal
+++ b/elm-compiler.cabal
@@ -121,7 +121,7 @@ Library
         ansi-terminal >= 0.6.2.1 && < 0.7,
         base >=4.2 && <5,
         binary >= 0.7.0.0 && < 0.8,
-        blaze-html >= 0.5 && < 0.8,
+        blaze-html >= 0.5 && < 0.9,
         blaze-markup >= 0.5.1 && < 0.8,
         bytestring >= 0.9 && < 0.11,
         cmdargs >= 0.7 && < 0.11,

--- a/elm-compiler.cabal
+++ b/elm-compiler.cabal
@@ -122,7 +122,7 @@ Library
         base >=4.2 && <5,
         binary >= 0.7.0.0 && < 0.8,
         blaze-html >= 0.5 && < 0.8,
-        blaze-markup >= 0.5.1 && < 0.7,
+        blaze-markup >= 0.5.1 && < 0.8,
         bytestring >= 0.9 && < 0.11,
         cmdargs >= 0.7 && < 0.11,
         containers >= 0.3 && < 0.6,


### PR DESCRIPTION
Are there specific reasons that `blaze-html` was constrained to `< 0.8` and `blaze-markup` to `< 0.7`?

These are the only constraints that currently keep this repository from building with the set of constraints given by "Long Term Support Haskell 3.1": https://www.stackage.org/lts-3.1/cabal.config