### PR TITLE
Add benchmarks to elm-compiler

### DIFF
--- a/bench/CompilerBenchmarks.elm
+++ b/bench/CompilerBenchmarks.elm
@@ -12,6 +12,9 @@ import ArrayBench
 import ListBench
 import AnimateBench
 import RecordBench
+import SmallRecordBench
+import TupleBench
+import SmallTupleBench
 
 
 {-| Compile this with --output=Benchmarks.html to generate
@@ -22,6 +25,9 @@ import RecordBench
 mySuite =
   Benchmark.Suite "My Suite" 
   [ Benchmark.bench1 "Access 20-field record 200 times:   " RecordBench.sumRandomElems indices200
+  , Benchmark.bench1 "Access 9-field record 200 times:   " SmallRecordBench.sumRandomElems indices200
+  , Benchmark.bench1 "Access 9-field tuple 200 times:   " TupleBench.sumRandomElems indices200
+  , Benchmark.bench1 "Access 3-field tuple 200 times:   " SmallTupleBench.sumRandomElems indices200
   
   , Benchmark.bench1 "Make and sum dict, 10000 elems:   " LargeDictionary.addNToDictAndSum 10000
   , Benchmark.bench1 "Make and sum dict, 50 elems:   " LargeDictionary.addNToDictAndSum 50

--- a/bench/CompilerBenchmarks.elm
+++ b/bench/CompilerBenchmarks.elm
@@ -18,6 +18,7 @@ import SmallTupleBench
 import CtorBench
 import SmallCtorBench
 import PatternMatchBench
+import IfBench
 
 {-| Compile this with --output=Benchmarks.html to generate
     a webpage, which runs the benchmarks and shows the results. 
@@ -34,6 +35,9 @@ mySuite =
   
   , Benchmark.bench1 "Access 20-constructor Type 200 times:   " CtorBench.sumFieldsList ctorData200
   , Benchmark.bench1 "Access 10-constructor Type 200 times:   " SmallCtorBench.sumFieldsList smallCtorData200
+  
+  , Benchmark.bench1 "Tail-recursive if function, called 200 times: " IfBench.tailRecSum indices200
+  , Benchmark.bench1 "Tail-recursive if function, called 200 times: " IfBench.manyConditionalSum indices200
   
   , Benchmark.bench1 "Pattern match 18-levels deep, use all values, 200 times " PatternMatchBench.deepMatchSum nestedData200
   , Benchmark.bench1 "Pattern match 18-levels deep, 16 wildcards, 200 times " PatternMatchBench.wildcardMatchSum nestedData200

--- a/bench/CompilerBenchmarks.elm
+++ b/bench/CompilerBenchmarks.elm
@@ -37,7 +37,8 @@ mySuite =
   , Benchmark.bench1 "Access 10-constructor Type 200 times:   " SmallCtorBench.sumFieldsList smallCtorData200
   
   , Benchmark.bench1 "Tail-recursive if function, called 200 times: " IfBench.tailRecSum indices200
-  , Benchmark.bench1 "Tail-recursive if function, called 200 times: " IfBench.manyConditionalSum indices200
+  , Benchmark.bench1 "If expression with 20 branches, called 200 times: " IfBench.manyConditionalSum indices200
+  , Benchmark.bench1 "If expression with 4 branches, called 200 times: " IfBench.fewConditionalSum indices200
   
   , Benchmark.bench1 "Pattern match 18-levels deep, use all values, 200 times " PatternMatchBench.deepMatchSum nestedData200
   , Benchmark.bench1 "Pattern match 18-levels deep, 16 wildcards, 200 times " PatternMatchBench.wildcardMatchSum nestedData200

--- a/bench/CompilerBenchmarks.elm
+++ b/bench/CompilerBenchmarks.elm
@@ -17,6 +17,7 @@ import TupleBench
 import SmallTupleBench
 import CtorBench
 import SmallCtorBench
+import PatternMatchBench
 
 {-| Compile this with --output=Benchmarks.html to generate
     a webpage, which runs the benchmarks and shows the results. 
@@ -27,10 +28,16 @@ mySuite =
   Benchmark.Suite "My Suite" 
   [ Benchmark.bench1 "Access 20-field record 200 times:   " RecordBench.sumRandomElems indices200
   , Benchmark.bench1 "Access 9-field record 200 times:   " SmallRecordBench.sumRandomElems indices200
+  
   , Benchmark.bench1 "Access 9-field tuple 200 times:   " TupleBench.sumRandomElems indices200
   , Benchmark.bench1 "Access 3-field tuple 200 times:   " SmallTupleBench.sumRandomElems indices200
+  
   , Benchmark.bench1 "Access 20-constructor Type 200 times:   " CtorBench.sumFieldsList ctorData200
   , Benchmark.bench1 "Access 10-constructor Type 200 times:   " SmallCtorBench.sumFieldsList smallCtorData200
+  
+  , Benchmark.bench1 "Pattern match 18-levels deep, use all values, 200 times " PatternMatchBench.deepMatchSum nestedData200
+  , Benchmark.bench1 "Pattern match 18-levels deep, 16 wildcards, 200 times " PatternMatchBench.wildcardMatchSum nestedData200
+  , Benchmark.bench1 "Pattern match 4-levels deep, use all values, 200 times " PatternMatchBench.shallowMatchSum nestedData200
   
   , Benchmark.bench1 "Make and sum dict, 10000 elems:   " LargeDictionary.addNToDictAndSum 10000
   , Benchmark.bench1 "Make and sum dict, 50 elems:   " LargeDictionary.addNToDictAndSum 50
@@ -130,3 +137,7 @@ ctorData200 =
   
 smallCtorData200 = 
   List.map SmallCtorBench.makeRandomData indices200
+  
+  
+nestedData200 = 
+  List.map PatternMatchBench.intToNest indices200

--- a/bench/CompilerBenchmarks.elm
+++ b/bench/CompilerBenchmarks.elm
@@ -4,13 +4,16 @@ import Benchmark
 import Task exposing (Task, andThen)
 import Text
 import Array
+import Random
+import Time
 
 import LargeDictionary
 import ArrayBench
 import ListBench
 import AnimateBench
-import Random
-import Time
+import RecordBench
+
+
 {-| Compile this with --output=Benchmarks.html to generate
     a webpage, which runs the benchmarks and shows the results. 
 -}
@@ -18,25 +21,26 @@ import Time
 
 mySuite =
   Benchmark.Suite "My Suite" 
-  [ Benchmark.bench1 "Make and sum dict, 10000 elems:   " LargeDictionary.addNToDictAndSum 10000
-    , Benchmark.bench1 "Make and sum dict, 50 elems:   " LargeDictionary.addNToDictAndSum 50
+  [ Benchmark.bench1 "Access 20-field record 200 times" RecordBench.sumRandomElems indices200
+  , Benchmark.bench1 "Make and sum dict, 10000 elems:   " LargeDictionary.addNToDictAndSum 10000
+  , Benchmark.bench1 "Make and sum dict, 50 elems:   " LargeDictionary.addNToDictAndSum 50
 
-    , Benchmark.bench1 "Array native foldr, 500 elems:   " ArrayBench.foldrMeanStddev array500
-    , Benchmark.bench1 "Array native foldl, 500 elems:   " ArrayBench.foldlMeanStddev array500
-    , Benchmark.bench1 "Array custom foldr, 500 elems:   " ArrayBench.customFoldrMeanStddev array500
-    , Benchmark.bench1 "Array custom foldl, 500 elems:   " ArrayBench.customFoldrMeanStddev array500
-    , Benchmark.bench3 "Array square nth elem, 500 elems:   " ArrayBench.updateNRandomIndices (\x -> x*x) indices200 array500
+  , Benchmark.bench1 "Array native foldr, 500 elems:   " ArrayBench.foldrMeanStddev array500
+  , Benchmark.bench1 "Array native foldl, 500 elems:   " ArrayBench.foldlMeanStddev array500
+  , Benchmark.bench1 "Array custom foldr, 500 elems:   " ArrayBench.customFoldrMeanStddev array500
+  , Benchmark.bench1 "Array custom foldl, 500 elems:   " ArrayBench.customFoldrMeanStddev array500
+  , Benchmark.bench3 "Array square nth elem, 500 elems:   " ArrayBench.updateNRandomIndices (\x -> x*x) indices200 array500
 
-    , Benchmark.bench1 "List native foldr, 500 elems:   " ListBench.foldrMeanStddev list500
-    , Benchmark.bench1 "List native foldl, 500 elems:   " ListBench.foldlMeanStddev list500
-    , Benchmark.bench1 "List custom foldr, 500 elems:   " ListBench.customFoldrMeanStddev list500
-    , Benchmark.bench1 "List custom foldl, 500 elems:   " ListBench.customFoldrMeanStddev list500
-    , Benchmark.bench3 "List square nth elem, 500 elems:   " ListBench.updateNRandomIndices (\x -> x*x) indices200 list500
+  , Benchmark.bench1 "List native foldr, 500 elems:   " ListBench.foldrMeanStddev list500
+  , Benchmark.bench1 "List native foldl, 500 elems:   " ListBench.foldlMeanStddev list500
+  , Benchmark.bench1 "List custom foldr, 500 elems:   " ListBench.customFoldrMeanStddev list500
+  , Benchmark.bench1 "List custom foldl, 500 elems:   " ListBench.customFoldrMeanStddev list500
+  , Benchmark.bench3 "List square nth elem, 500 elems:   " ListBench.updateNRandomIndices (\x -> x*x) indices200 list500
 
-    , Benchmark.bench2 "200 lookups in array of 500 elems:   " ArrayBench.randomLookups indices200 (Array.fromList [1 .. 500] )
-    , Benchmark.bench2 "200 lookups in list of 500 elems:   " ListBench.randomLookups indices200 ([1 .. 500] )
+  , Benchmark.bench2 "200 lookups in array of 500 elems:   " ArrayBench.randomLookups indices200 (Array.fromList [1 .. 500] )
+  , Benchmark.bench2 "200 lookups in list of 500 elems:   " ListBench.randomLookups indices200 ([1 .. 500] )
     
-    , Benchmark.bench1 "30s simulated animation: " AnimateBench.runAnimation timeSteps30s
+  , Benchmark.bench1 "30s simulated animation @ 30fps: " AnimateBench.runAnimation timeSteps30s        
   ]
 
 

--- a/bench/CompilerBenchmarks.elm
+++ b/bench/CompilerBenchmarks.elm
@@ -21,7 +21,8 @@ import RecordBench
 
 mySuite =
   Benchmark.Suite "My Suite" 
-  [ Benchmark.bench1 "Access 20-field record 200 times" RecordBench.sumRandomElems indices200
+  [ Benchmark.bench1 "Access 20-field record 200 times:   " RecordBench.sumRandomElems indices200
+  
   , Benchmark.bench1 "Make and sum dict, 10000 elems:   " LargeDictionary.addNToDictAndSum 10000
   , Benchmark.bench1 "Make and sum dict, 50 elems:   " LargeDictionary.addNToDictAndSum 50
 
@@ -40,7 +41,7 @@ mySuite =
   , Benchmark.bench2 "200 lookups in array of 500 elems:   " ArrayBench.randomLookups indices200 (Array.fromList [1 .. 500] )
   , Benchmark.bench2 "200 lookups in list of 500 elems:   " ListBench.randomLookups indices200 ([1 .. 500] )
     
-  , Benchmark.bench1 "30s simulated animation @ 30fps: " AnimateBench.runAnimation timeSteps30s        
+  , Benchmark.bench1 "30s simulated animation @ 30fps:   " AnimateBench.runAnimation timeSteps30s        
   ]
 
 

--- a/bench/CompilerBenchmarks.elm
+++ b/bench/CompilerBenchmarks.elm
@@ -16,6 +16,7 @@ import SmallRecordBench
 import TupleBench
 import SmallTupleBench
 import CtorBench
+import SmallCtorBench
 
 {-| Compile this with --output=Benchmarks.html to generate
     a webpage, which runs the benchmarks and shows the results. 
@@ -29,6 +30,7 @@ mySuite =
   , Benchmark.bench1 "Access 9-field tuple 200 times:   " TupleBench.sumRandomElems indices200
   , Benchmark.bench1 "Access 3-field tuple 200 times:   " SmallTupleBench.sumRandomElems indices200
   , Benchmark.bench1 "Access 20-constructor Type 200 times:   " CtorBench.sumFieldsList ctorData200
+  , Benchmark.bench1 "Access 10-constructor Type 200 times:   " SmallCtorBench.sumFieldsList smallCtorData200
   
   , Benchmark.bench1 "Make and sum dict, 10000 elems:   " LargeDictionary.addNToDictAndSum 10000
   , Benchmark.bench1 "Make and sum dict, 50 elems:   " LargeDictionary.addNToDictAndSum 50
@@ -127,3 +129,7 @@ timeSteps30s =
 
 ctorData200 = 
   List.map CtorBench.makeRandomData indices200
+  
+  
+smallCtorData200 = 
+  List.map SmallCtorBench.makeRandomData indices200

--- a/bench/CompilerBenchmarks.elm
+++ b/bench/CompilerBenchmarks.elm
@@ -15,7 +15,7 @@ import RecordBench
 import SmallRecordBench
 import TupleBench
 import SmallTupleBench
-
+import CtorBench
 
 {-| Compile this with --output=Benchmarks.html to generate
     a webpage, which runs the benchmarks and shows the results. 
@@ -28,6 +28,7 @@ mySuite =
   , Benchmark.bench1 "Access 9-field record 200 times:   " SmallRecordBench.sumRandomElems indices200
   , Benchmark.bench1 "Access 9-field tuple 200 times:   " TupleBench.sumRandomElems indices200
   , Benchmark.bench1 "Access 3-field tuple 200 times:   " SmallTupleBench.sumRandomElems indices200
+  , Benchmark.bench1 "Access 20-constructor Type 200 times:   " CtorBench.sumFieldsList ctorData200
   
   , Benchmark.bench1 "Make and sum dict, 10000 elems:   " LargeDictionary.addNToDictAndSum 10000
   , Benchmark.bench1 "Make and sum dict, 50 elems:   " LargeDictionary.addNToDictAndSum 50
@@ -124,3 +125,5 @@ indices200 =
 timeSteps30s = 
   List.map (\x -> (1.0 / 30.0) * (toFloat x * Time.second) ) [1 .. 900]
 
+ctorData200 = 
+  List.map CtorBench.makeRandomData indices200

--- a/bench/CompilerBenchmarks.elm
+++ b/bench/CompilerBenchmarks.elm
@@ -11,7 +11,7 @@ import Time
 import LargeDictionary
 import ArrayBench
 import ListBench
-import AnimateBench
+
 import RecordBench
 import SmallRecordBench
 import TupleBench
@@ -21,6 +21,9 @@ import SmallCtorBench
 import PatternMatchBench
 import IfBench
 import DictBench
+
+import AnimateBench
+import TodoBench
 
 {-| Compile this with --output=Benchmarks.html to generate
     a webpage, which runs the benchmarks and shows the results. 
@@ -69,7 +72,8 @@ mySuite =
   , Benchmark.bench2 "200 lookups in list of 500 elems:   " ListBench.randomLookups indices200 ([1 .. 500] )
   , Benchmark.bench2 "200 lookups in dict of 500 elems:   " DictBench.randomLookups indices200 (Dict.fromList (List.map2 (,) [1 .. 500] [1 .. 500]) )
     
-  , Benchmark.bench1 "30s simulated animation @ 30fps:   " AnimateBench.runAnimation timeSteps30s        
+  , Benchmark.bench1 "30s simulated animation @ 30fps:   " AnimateBench.runAnimation timeSteps30s
+  , Benchmark.bench1 "TodoMVC: approx. 330 simulated actions   " TodoBench.evalActions TodoBench.testActions
   ]
 
 

--- a/bench/CompilerBenchmarks.elm
+++ b/bench/CompilerBenchmarks.elm
@@ -75,10 +75,7 @@ main =
 
 
 
-{-
-Random generation and structures
--}
-
+-- Random generation and structures
 
 --Maximum size for  random numbers
 maxSize = 1000000

--- a/bench/CompilerBenchmarks.elm
+++ b/bench/CompilerBenchmarks.elm
@@ -8,6 +8,7 @@ import Array
 import LargeDictionary
 import ArrayBench
 import ListBench
+import AnimateBench
 import Random
 import Time
 {-| Compile this with --output=Benchmarks.html to generate
@@ -34,6 +35,8 @@ mySuite =
 
     , Benchmark.bench2 "200 lookups in array of 500 elems:   " ArrayBench.randomLookups indices200 (Array.fromList [1 .. 500] )
     , Benchmark.bench2 "200 lookups in list of 500 elems:   " ListBench.randomLookups indices200 ([1 .. 500] )
+    
+    , Benchmark.bench1 "30s simulated animation: " AnimateBench.runAnimation timeSteps30s
   ]
 
 
@@ -82,21 +85,31 @@ indexGen =
 --across multiple runs of the benchmark
 
 --seed for our index generation
-indexSeed = Random.initialSeed 56
+indexSeed = 
+  Random.initialSeed 56
 
 
 --Seed for our float generation
-seed = Random.initialSeed 23
+seed = 
+  Random.initialSeed 23
 
 
 --Pseudo-random array of 500 floating point numbers
-array500 = (ArrayBench.randomArray floatGen 500 seed)
+array500 = 
+  (ArrayBench.randomArray floatGen 500 seed)
 
 
 --Same contents as array500, but in list form
-list500 = (ListBench.randomList floatGen 500 seed)
+list500 = 
+  (ListBench.randomList floatGen 500 seed)
 
 
 --Pseudo random list of 200 indices between 0 and 499
-indices200 = (ListBench.randomList indexGen 200 indexSeed)
+indices200 = 
+  (ListBench.randomList indexGen 200 indexSeed)
+
+
+--List of timesteps simulating 30 seconds of animation at 30fps
+timeSteps30s = 
+  List.map (\x -> (1.0 / 30.0) * (toFloat x * Time.second) ) [1 .. 900]
 

--- a/bench/CompilerBenchmarks.elm
+++ b/bench/CompilerBenchmarks.elm
@@ -24,11 +24,13 @@ mySuite =
     , Benchmark.bench1 "Array native foldl, 500 elems:   " ArrayBench.foldlMeanStddev array500
     , Benchmark.bench1 "Array custom foldr, 500 elems:   " ArrayBench.customFoldrMeanStddev array500
     , Benchmark.bench1 "Array custom foldl, 500 elems:   " ArrayBench.customFoldrMeanStddev array500
+    , Benchmark.bench3 "Array square nth elem, 500 elems:   " ArrayBench.updateNRandomIndices (\x -> x*x) indices200 array500
 
     , Benchmark.bench1 "List native foldr, 500 elems:   " ListBench.foldrMeanStddev list500
     , Benchmark.bench1 "List native foldl, 500 elems:   " ListBench.foldlMeanStddev list500
     , Benchmark.bench1 "List custom foldr, 500 elems:   " ListBench.customFoldrMeanStddev list500
     , Benchmark.bench1 "List custom foldl, 500 elems:   " ListBench.customFoldrMeanStddev list500
+    , Benchmark.bench3 "List square nth elem, 500 elems:   " ListBench.updateNRandomIndices (\x -> x*x) indices200 list500
 
     , Benchmark.bench2 "200 lookups in array of 500 elems:   " ArrayBench.randomLookups indices200 (Array.fromList [1 .. 500] )
     , Benchmark.bench2 "200 lookups in list of 500 elems:   " ListBench.randomLookups indices200 ([1 .. 500] )
@@ -52,7 +54,7 @@ port benchResults =
 
 --Our main page:
 main =
- Signal.map2 (\s1 s2 -> Graphics.Element.leftAligned <| Text.fromString (s1 ++ " " ++ (toString s2) )  ) results.signal (Time.every Time.second)
+ Signal.map (Graphics.Element.leftAligned << Text.fromString) results.signal
 
 
 

--- a/bench/CompilerBenchmarks.elm
+++ b/bench/CompilerBenchmarks.elm
@@ -1,0 +1,100 @@
+import Graphics.Element exposing (show)
+import Signal
+import Benchmark
+import Task exposing (Task, andThen)
+import Text
+import Array
+
+import LargeDictionary
+import ArrayBench
+import ListBench
+import Random
+import Time
+{-| Compile this with --output=Benchmarks.html to generate
+    a webpage, which runs the benchmarks and shows the results. 
+-}
+
+
+mySuite =
+  Benchmark.Suite "My Suite" 
+  [ Benchmark.bench1 "Make and sum dict, 10000 elems:   " LargeDictionary.addNToDictAndSum 10000
+    , Benchmark.bench1 "Make and sum dict, 50 elems:   " LargeDictionary.addNToDictAndSum 50
+
+    , Benchmark.bench1 "Array native foldr, 500 elems:   " ArrayBench.foldrMeanStddev array500
+    , Benchmark.bench1 "Array native foldl, 500 elems:   " ArrayBench.foldlMeanStddev array500
+    , Benchmark.bench1 "Array custom foldr, 500 elems:   " ArrayBench.customFoldrMeanStddev array500
+    , Benchmark.bench1 "Array custom foldl, 500 elems:   " ArrayBench.customFoldrMeanStddev array500
+
+    , Benchmark.bench1 "List native foldr, 500 elems:   " ListBench.foldrMeanStddev list500
+    , Benchmark.bench1 "List native foldl, 500 elems:   " ListBench.foldlMeanStddev list500
+    , Benchmark.bench1 "List custom foldr, 500 elems:   " ListBench.customFoldrMeanStddev list500
+    , Benchmark.bench1 "List custom foldl, 500 elems:   " ListBench.customFoldrMeanStddev list500
+
+    , Benchmark.bench2 "200 lookups in array of 500 elems:   " ArrayBench.randomLookups indices200 (Array.fromList [1 .. 500] )
+    , Benchmark.bench2 "200 lookups in list of 500 elems:   " ListBench.randomLookups indices200 ([1 .. 500] )
+  ]
+
+
+--Display of results:
+
+--Mailbox updated with benchmark run progress
+results : Signal.Mailbox String
+results =
+  Signal.mailbox "Benchmark loading"
+
+
+--The actual task which runs the benchmarks
+port benchResults : (Task Benchmark.Never ())
+port benchResults =
+  Benchmark.runWithProgress (Just results) mySuite
+  `andThen` \_ -> Task.sleep 0
+
+
+--Our main page:
+main =
+ Signal.map2 (\s1 s2 -> Graphics.Element.leftAligned <| Text.fromString (s1 ++ " " ++ (toString s2) )  ) results.signal (Time.every Time.second)
+
+
+
+{-
+Random generation and structures
+-}
+
+
+--Maximum size for  random numbers
+maxSize = 1000000
+
+
+--Random generator for floating point numbers
+floatGen =
+  Random.float (-1 * maxSize) (maxSize)
+
+
+--Generate random indices for lists out of 500 elements
+indexGen =
+  Random.int (0) (499)
+
+
+--Random seeds: they're fixed, so it's not truly random
+--But we get seemingly random data, that we can compare fairly
+--across multiple runs of the benchmark
+
+--seed for our index generation
+indexSeed = Random.initialSeed 56
+
+
+--Seed for our float generation
+seed = Random.initialSeed 23
+
+
+--Pseudo-random array of 500 floating point numbers
+array500 = (ArrayBench.randomArray floatGen 500 seed)
+
+
+--Same contents as array500, but in list form
+list500 = (ListBench.randomList floatGen 500 seed)
+
+
+--Pseudo random list of 200 indices between 0 and 499
+indices200 = (ListBench.randomList indexGen 200 indexSeed)
+

--- a/bench/CompilerBenchmarks.elm
+++ b/bench/CompilerBenchmarks.elm
@@ -5,6 +5,7 @@ import Task exposing (Task, andThen)
 import Text
 import Array
 import Random
+import Dict
 import Time
 
 import LargeDictionary
@@ -19,6 +20,7 @@ import CtorBench
 import SmallCtorBench
 import PatternMatchBench
 import IfBench
+import DictBench
 
 {-| Compile this with --output=Benchmarks.html to generate
     a webpage, which runs the benchmarks and shows the results. 
@@ -53,6 +55,10 @@ mySuite =
   , Benchmark.bench1 "Array custom foldl, 500 elems:   " ArrayBench.customFoldrMeanStddev array500
   , Benchmark.bench3 "Array square nth elem, 500 elems:   " ArrayBench.updateNRandomIndices (\x -> x*x) indices200 array500
 
+  , Benchmark.bench1 "Dict native foldr, 500 elems:   " DictBench.foldrMeanStddev dict500
+  , Benchmark.bench1 "Dict native foldl, 500 elems:   " DictBench.foldlMeanStddev dict500
+  , Benchmark.bench3 "Dict square nth elem, 500 elems:   " DictBench.updateNRandomIndices (\x -> x*x) indices200 dict500  
+  
   , Benchmark.bench1 "List native foldr, 500 elems:   " ListBench.foldrMeanStddev list500
   , Benchmark.bench1 "List native foldl, 500 elems:   " ListBench.foldlMeanStddev list500
   , Benchmark.bench1 "List custom foldr, 500 elems:   " ListBench.customFoldrMeanStddev list500
@@ -61,6 +67,7 @@ mySuite =
 
   , Benchmark.bench2 "200 lookups in array of 500 elems:   " ArrayBench.randomLookups indices200 (Array.fromList [1 .. 500] )
   , Benchmark.bench2 "200 lookups in list of 500 elems:   " ListBench.randomLookups indices200 ([1 .. 500] )
+  , Benchmark.bench2 "200 lookups in dict of 500 elems:   " DictBench.randomLookups indices200 (Dict.fromList (List.map2 (,) [1 .. 500] [1 .. 500]) )
     
   , Benchmark.bench1 "30s simulated animation @ 30fps:   " AnimateBench.runAnimation timeSteps30s        
   ]
@@ -120,6 +127,12 @@ seed =
 --Pseudo-random array of 500 floating point numbers
 array500 = 
   (ArrayBench.randomArray floatGen 500 seed)
+  
+  
+--Pseudo-random dictionary, indexed 0 .. 500, of 500 floating point numbers
+dict500 = 
+  (DictBench.randomDict floatGen 500 seed)
+
 
 
 --Same contents as array500, but in list form

--- a/bench/elm-package.json
+++ b/bench/elm-package.json
@@ -1,0 +1,15 @@
+{
+    "version": "1.0.0",
+    "summary": "Benchmarking based on benchmark.js",
+    "repository": "https://github.com/JoeyEremondi/elm-benchmark.git",
+    "license": "BSD3",
+    "source-directories": [
+        "src"
+    ],
+    "exposed-modules": [],
+    "native-modules": true,
+    "dependencies": {
+        "elm-lang/core": "2.1.0 <= v < 3.0.0"
+    },
+    "elm-version": "0.15.1 <= v < 0.16.0"
+}

--- a/bench/src/AnimateBench.elm
+++ b/bench/src/AnimateBench.elm
@@ -1,0 +1,58 @@
+module AnimateBench where
+
+import Time exposing (Time)
+
+
+{-| Main Spring Type.
+A spring's behavior is defined by its stiffness and damping parameters.
+-}
+type alias Spring a =
+  { stiffness   : Float
+  , damping     : Float
+  , position    : a
+  , velocity    : a
+  , destination : a
+  }
+  
+
+defaultSpring  = 
+  Spring 1.0 0.5 0.0 1.0 100.0
+
+  
+epsilon = 0.0001
+
+  
+{-| Animate a spring given a framerate.
+
+    animate framerate spring
+-}
+animate : Time -> Spring Float -> Spring Float
+animate fpms spring =
+  let
+      frameRate = fpms / 1000
+
+      fspring = -spring.stiffness * (spring.position - spring.destination)
+
+      fdamper = -spring.damping  * spring.velocity
+
+      a = fspring + fdamper
+
+      newV = spring.velocity + a * frameRate
+      newX = spring.position + newV * frameRate
+  in
+      if
+          abs (newV - spring.velocity) < epsilon && abs (newX - spring.position) < epsilon
+      then
+          { spring | position <- spring.destination
+                   , velocity <- 0
+          }
+      else
+          { spring | position <- newX
+                   , velocity <- newV
+          }  
+
+          
+
+runAnimation : List Float -> Spring Float
+runAnimation timeSteps = 
+  List.foldr animate defaultSpring timeSteps

--- a/bench/src/ArrayBench.elm
+++ b/bench/src/ArrayBench.elm
@@ -1,0 +1,73 @@
+module ArrayBench where
+
+import Array
+import Random
+
+
+
+randomArray 
+  :  Random.Generator a 
+  -> Int 
+  -> Random.Seed 
+  -> Array.Array a
+randomArray gen n initSeed =
+  let
+    f n (seed, accum) =
+      let
+        (nextToAdd, newSeed) = Random.generate gen seed
+        newAccum = Array.push nextToAdd accum
+      in (newSeed, newAccum)
+  in 
+    snd <| List.foldl f (initSeed, Array.empty) [1 .. n]
+
+meanAndStddev 
+  :  ((Float -> (Float, Float) -> (Float, Float)) -> (Float, Float) -> Array.Array Float -> (Float, Float)) 
+  -> Array.Array Float
+  -> (Float, Float)
+meanAndStddev foldFn ourArray =
+  let 
+    --ourArray = randomArray n (Random.initialSeed 23)
+    (theSum, sumSq) = foldFn (\x (sum, sumSq) -> (x + sum, (x^2) + sumSq) ) (0,0) ourArray
+  in
+    (theSum, sqrt(theSum*theSum - sumSq))
+    
+
+foldrMeanStddev = meanAndStddev Array.foldr
+
+foldlMeanStddev = meanAndStddev Array.foldl
+
+customFoldrMeanStddev = meanAndStddev myFoldr 
+
+customFoldlMeanStddev = meanAndStddev myFoldl
+
+
+randomLookups : List Int -> Array.Array Float -> List (Maybe Float)
+randomLookups indices arr =
+  List.map (\i -> Array.get i arr) indices
+
+
+
+myFoldl : (a -> b -> b) -> b -> Array.Array a -> b
+myFoldl f init arr = 
+  let
+    len = Array.length arr
+    fromJust (Just x) = x 
+    helper init i = 
+      if (i >= len)
+      then init
+      else
+        helper (f (fromJust <| Array.get i arr) init) (i+1)
+  in helper init 0
+
+
+myFoldr : (a -> b -> b) -> b -> Array.Array a -> b
+myFoldr f init arr = 
+  let
+    len = Array.length arr
+    fromJust (Just x) = x 
+    helper init i = 
+      if (i <= 0)
+      then init
+      else
+        helper (f (fromJust <| Array.get i arr) init) (i-1)
+  in helper init (len-1)

--- a/bench/src/ArrayBench.elm
+++ b/bench/src/ArrayBench.elm
@@ -35,11 +35,15 @@ meanAndStddev foldFn ourArray =
 
 foldrMeanStddev = meanAndStddev Array.foldr
 
+
 foldlMeanStddev = meanAndStddev Array.foldl
+
 
 customFoldrMeanStddev = meanAndStddev myFoldr 
 
+
 customFoldlMeanStddev = meanAndStddev myFoldl
+
 
 updateNRandomIndices
   :  (Float -> Float)
@@ -55,7 +59,6 @@ updateNRandomIndices f indexList startList =
 randomLookups : List Int -> Array.Array Float -> List (Maybe Float)
 randomLookups indices arr =
   List.map (\i -> Array.get i arr) indices
-
 
 
 myFoldl : (a -> b -> b) -> b -> Array.Array a -> b
@@ -82,6 +85,7 @@ myFoldr f init arr =
       else
         helper (f (fromJust <| Array.get i arr) init) (i-1)
   in helper init (len-1)
+
   
 updateN : Int -> (a -> a) -> Array.Array a -> Array.Array a
 updateN n f arr = 

--- a/bench/src/ArrayBench.elm
+++ b/bench/src/ArrayBench.elm
@@ -2,6 +2,7 @@ module ArrayBench where
 
 import Array
 import Random
+import Debug exposing (crash)
 
 
 
@@ -40,6 +41,16 @@ customFoldrMeanStddev = meanAndStddev myFoldr
 
 customFoldlMeanStddev = meanAndStddev myFoldl
 
+updateNRandomIndices
+  :  (Float -> Float)
+  -> List Int
+  -> Array.Array Float
+  -> Array.Array Float
+updateNRandomIndices f indexList startList = 
+  List.foldr 
+  (\ i oldList -> updateN i f oldList)
+  startList indexList
+
 
 randomLookups : List Int -> Array.Array Float -> List (Maybe Float)
 randomLookups indices arr =
@@ -71,3 +82,9 @@ myFoldr f init arr =
       else
         helper (f (fromJust <| Array.get i arr) init) (i-1)
   in helper init (len-1)
+  
+updateN : Int -> (a -> a) -> Array.Array a -> Array.Array a
+updateN n f arr = 
+  case Array.get n arr of
+    Just x -> Array.set n (f x) arr
+    _ -> crash "Array out of bounds"

--- a/bench/src/Benchmark.elm
+++ b/bench/src/Benchmark.elm
@@ -1,0 +1,212 @@
+module Benchmark
+    ( Never
+    , Benchmark
+    , Suite (..)
+    , BenchStats
+    , run
+    , runWithProgress
+    , bench
+    , bench1
+    , bench2
+    , bench3
+    , bench4
+    , bench5
+    , bench6
+    , bench7
+    , bench8
+    , bench9
+    )where
+{-| A wrapper around benchmark.js that allows benchmarking
+of pure functions to be evaluated.
+
+# Error and Benchmark types
+@docs Never, Benchmark, Suite, BenchStats
+
+# Running benchmarks
+@docs run, runWithProgress
+
+# Creating benchmarks
+@docs bench, bench1, bench2, bench3, bench4, bench5, bench6, bench7, bench8, bench9
+-}
+
+
+import Task
+import String
+import Native.Benchmark
+import Native.BenchmarkJS
+import Signal
+import Time
+
+
+{-|
+Our error return type: can never be instantiated
+because running benchmarks should not fail
+|-}
+type Never = 
+    Never Never
+
+
+{-|
+Opaque type representing a function to be timed
+|-}
+type Benchmark = 
+    Benchmark
+
+
+{-|
+The results of running a benchmark
+|-}
+type BenchStats = 
+  BenchStats 
+  { name : String
+  , hz : Float
+  , marginOfError : Float
+  , moePercent : Float
+--  , numRunsSampled : Int
+  }
+
+
+{-|
+A single or collection of benchmarks
+that can be run, generating output
+|-}
+type Suite = 
+      SingleBenchmark Benchmark
+    | Suite String (List Benchmark)
+
+
+{-|
+Run a benchmark, generating a list of results for each benchmark.
+Results contain a pretty-printed string summary, and a list
+of detailed data for each benchmark.
+|-}
+run 
+  :  Suite 
+  -> Task.Task Never (String, List BenchStats)
+run = runWithProgress Nothing
+
+
+{-|
+Run a benchmark, generating a list of results for each benchmark
+and updating a String signal with progress as the benchmarks run
+|-}
+runWithProgress 
+  :  Maybe (Signal.Mailbox String) 
+  -> Suite 
+  -> Task.Task Never (String, List BenchStats)
+runWithProgress maybeMailbox suite = 
+  let
+    ourTask = 
+      case maybeMailbox of
+        Nothing -> \_ -> Task.sleep 0
+        Just mailbox -> 
+          \s ->
+            (Signal.send mailbox.address s
+            `Task.andThen` \_ -> Task.sleep (5*Time.second))
+          -- `Task.andThen` \_ -> Task.keepGoing
+  in
+    Native.Benchmark.runWithProgress ourTask suite 
+
+{-|
+Create a benchmark with the given name
+running an arbitrary thunk
+|-}
+bench : String -> (() -> result) -> Benchmark
+bench = Native.Benchmark.makeBenchmark 
+
+
+{-|
+Functions for creating named benchmarks with 1 to 9 arguments
+|-}
+bench1 : String -> (a -> result) -> a -> Benchmark
+bench1 name f a = 
+    Native.Benchmark.makeBenchmark name (\_ -> f a)
+
+
+{-||-}
+bench2 : String -> (a -> b -> result) -> a -> b -> Benchmark
+bench2 name f a b = 
+    Native.Benchmark.makeBenchmark name (\_ -> f a b)
+
+
+{-||-}
+bench3 : String -> (a -> b -> c -> result) -> a -> b -> c -> Benchmark
+bench3 name f a b c = 
+    Native.Benchmark.makeBenchmark name (\_ -> f a b c)
+
+
+{-||-}
+bench4 : String -> (a -> b -> c -> d -> result) -> a -> b -> c -> d -> Benchmark
+bench4 name f a b c d = 
+    Native.Benchmark.makeBenchmark name (\_ -> f a b c d)
+
+
+{-||-}
+bench5 : String -> (a -> b -> c -> d -> e -> result) -> a -> b -> c -> d -> e -> Benchmark
+bench5 name f a b c d e = 
+    Native.Benchmark.makeBenchmark name (\_ -> f a b c d e)
+
+
+{-||-}
+bench6 : 
+  String 
+  -> (a -> b -> c -> d -> e -> f -> result) 
+  -> a 
+  -> b 
+  -> c 
+  -> d 
+  -> e 
+  -> f 
+  -> Benchmark
+bench6 name fn a b c d e f = 
+    Native.Benchmark.makeBenchmark name (\_ -> fn a b c d e f)
+
+
+{-||-}
+bench7 :
+  String
+  -> (a -> b -> c -> d -> e -> f -> g -> result)
+  -> a 
+  -> b 
+  -> c 
+  -> d 
+  -> e 
+  -> f 
+  -> g
+  -> Benchmark
+bench7 name fn a b c d e f g = 
+    Native.Benchmark.makeBenchmark name (\_ -> fn a b c d e f g)
+
+
+{-||-}
+bench8 : 
+  String 
+  -> (a -> b -> c -> d -> e -> f -> g -> h -> result)
+  -> a 
+  -> b 
+  -> c 
+  -> d 
+  -> e 
+  -> f 
+  -> g
+  -> h
+  -> Benchmark
+bench8 name fn a b c d e f g h = 
+    Native.Benchmark.makeBenchmark name  (\_ -> fn a b c d e f g h)
+
+{-||-}
+bench9 :
+  String 
+  -> (a -> b -> c -> d -> e -> f -> g -> h -> i -> result)
+  -> a 
+  -> b 
+  -> c 
+  -> d 
+  -> e 
+  -> f 
+  -> g
+  -> h
+  -> i
+  -> Benchmark
+bench9 name fn a b c d e f g h i = 
+    Native.Benchmark.makeBenchmark name (\_ -> fn a b c d e f g h i)

--- a/bench/src/CtorBench.elm
+++ b/bench/src/CtorBench.elm
@@ -1,0 +1,135 @@
+module CtorBench where
+
+type ManyCtors = 
+    MyLongNamedCtor1 Float Float Float
+  | MyLongNamedCtor2 Float Float
+  | MyLongNamedCtor3 Float Float Float
+  | MyLongNamedCtor4 Float Float
+  | MyLongNamedCtor5 Float Float Float
+  | MyLongNamedCtor6 Float Float
+  | MyLongNamedCtor7 Float Float Float
+  | MyLongNamedCtor8 Float Float
+  | MyLongNamedCtor9 Float Float Float
+  | MyLongNamedCtor10 Float Float
+  | MyLongNamedCtor11 Float Float Float
+  | MyLongNamedCtor12 Float Float
+  | MyLongNamedCtor13 Float Float Float
+  | MyLongNamedCtor14 Float Float
+  | MyLongNamedCtor15 Float Float Float
+  | MyLongNamedCtor16 Float Float
+  | MyLongNamedCtor17 Float Float Float
+  | MyLongNamedCtor18 Float Float
+  | MyLongNamedCtor19 Float Float Float
+  | MyLongNamedCtor20 Float Float
+  
+
+getFieldSum someData = 
+  case someData of
+    MyLongNamedCtor1 x y z ->
+      x + y + z
+    
+    MyLongNamedCtor3 x y z ->
+      x + y + z
+    
+    MyLongNamedCtor5 x y z ->
+      x + y + z
+    
+    MyLongNamedCtor7 x y z ->
+      x + y + z
+    
+    MyLongNamedCtor9 x y z ->
+      x + y + z
+    
+    MyLongNamedCtor11 x y z ->
+      x + y + z
+    
+    MyLongNamedCtor13 x y z ->
+      x + y + z
+    
+    MyLongNamedCtor15 x y z ->
+      x + y + z
+    
+    MyLongNamedCtor17 x y z ->
+      x + y + z
+    
+    MyLongNamedCtor19 x y z ->
+      x + y + z
+    
+    MyLongNamedCtor20 x y ->
+      x + y
+    
+    MyLongNamedCtor18 x y ->
+      x + y
+      
+    MyLongNamedCtor16 x y ->
+      x + y
+      
+    MyLongNamedCtor14 x y ->
+      x + y
+    
+    MyLongNamedCtor12 x y ->
+      x + y
+    
+    MyLongNamedCtor10 x y ->
+      x + y
+    
+    MyLongNamedCtor8 x y ->
+      x + y
+    
+    MyLongNamedCtor6 x y ->
+      x + y
+    
+    MyLongNamedCtor4 x y ->
+      x + y
+    
+    MyLongNamedCtor2 x y ->
+      x + y
+      
+
+makeRandomData i = 
+  case (i % 20) of
+    0 -> 
+      MyLongNamedCtor20 (toFloat i) (toFloat <| i*i)
+    1 -> 
+      MyLongNamedCtor1 (toFloat i) (toFloat <| i*i) (toFloat <| i*i*i)
+    2 -> 
+      MyLongNamedCtor2 (toFloat i) (toFloat <| i*i)
+    3 -> 
+      MyLongNamedCtor3 (toFloat i) (toFloat <| i*i) (toFloat <| i*i*i)
+    4 -> 
+      MyLongNamedCtor4 (toFloat i) (toFloat <| i*i)
+    5 -> 
+      MyLongNamedCtor5 (toFloat i) (toFloat <| i*i) (toFloat <| i*i*i)
+    6 -> 
+      MyLongNamedCtor6 (toFloat i) (toFloat <| i*i)
+    7 -> 
+      MyLongNamedCtor7 (toFloat i) (toFloat <| i*i) (toFloat <| i*i*i)
+    8 -> 
+      MyLongNamedCtor8 (toFloat i) (toFloat <| i*i)
+    9 -> 
+      MyLongNamedCtor9 (toFloat i) (toFloat <| i*i) (toFloat <| i*i*i)
+    10 -> 
+      MyLongNamedCtor10 (toFloat i) (toFloat <| i*i)
+    11 -> 
+      MyLongNamedCtor11 (toFloat i) (toFloat <| i*i) (toFloat <| i*i*i)
+    12 -> 
+      MyLongNamedCtor12 (toFloat i) (toFloat <| i*i)
+    13 -> 
+      MyLongNamedCtor13 (toFloat i) (toFloat <| i*i) (toFloat <| i*i*i)
+    14 -> 
+      MyLongNamedCtor14 (toFloat i) (toFloat <| i*i)
+    15 -> 
+      MyLongNamedCtor15 (toFloat i) (toFloat <| i*i) (toFloat <| i*i*i)
+    16 -> 
+      MyLongNamedCtor16 (toFloat i) (toFloat <| i*i)
+    17 -> 
+      MyLongNamedCtor17 (toFloat i) (toFloat <| i*i) (toFloat <| i*i*i)
+    18 -> 
+      MyLongNamedCtor18 (toFloat i) (toFloat <| i*i)
+    19 -> 
+      MyLongNamedCtor19 (toFloat i) (toFloat <| i*i) (toFloat <| i*i*i)
+      
+
+sumFieldsList : List ManyCtors -> Float
+sumFieldsList dataList = 
+  List.foldr (\val sumSoFar -> (getFieldSum val) + sumSoFar ) 0.0 dataList

--- a/bench/src/DictBench.elm
+++ b/bench/src/DictBench.elm
@@ -1,0 +1,63 @@
+module DictBench where
+
+import Dict
+import Random
+import Debug exposing (crash)
+
+
+
+randomDict 
+  :  Random.Generator a 
+  -> Int 
+  -> Random.Seed 
+  -> Dict.Dict Int a
+randomDict gen n initSeed =
+  let
+    f n (seed, accum) =
+      let
+        (nextToAdd, newSeed) = Random.generate gen seed
+        newAccum = Dict.insert n nextToAdd accum
+      in (newSeed, newAccum)
+  in 
+    snd <| List.foldl f (initSeed, Dict.empty) [1 .. n]
+
+meanAndStddev 
+  :  ((Int -> Float -> (Float, Float) -> (Float, Float)) -> (Float, Float) -> Dict.Dict Int Float -> (Float, Float)) 
+  -> Dict.Dict Int Float
+  -> (Float, Float)
+meanAndStddev foldFn ourDict =
+  let 
+    --ourDict = randomDict n (Random.initialSeed 23)
+    (theSum, sumSq) = foldFn (\_ x (sum, sumSq) -> (x + sum, (x^2) + sumSq) ) (0,0) ourDict
+  in
+    (theSum, sqrt(theSum*theSum - sumSq))
+    
+
+foldrMeanStddev = meanAndStddev Dict.foldr
+
+
+foldlMeanStddev = meanAndStddev Dict.foldl
+
+
+updateNRandomIndices
+  :  (Float -> Float)
+  -> List Int
+  -> Dict.Dict Int Float
+  -> Dict.Dict Int Float
+updateNRandomIndices f indexList startList = 
+  List.foldr 
+  (\ i oldList -> updateN i f oldList)
+  startList indexList
+
+
+randomLookups : List Int -> Dict.Dict Int Float -> List (Maybe Float)
+randomLookups indices arr =
+  List.map (\i -> Dict.get i arr) indices
+
+
+  
+updateN : Int -> (a -> a) -> Dict.Dict Int a -> Dict.Dict Int a
+updateN n f arr = 
+  case Dict.get n arr of
+    Just x -> Dict.insert n (f x) arr
+    _ -> crash "Dict out of bounds"

--- a/bench/src/IfBench.elm
+++ b/bench/src/IfBench.elm
@@ -39,6 +39,32 @@ manyConditionFunction i =
       59.0 + (toFloat i)
     | (i == 105) ->
       69.0 + (toFloat i)
+    | (i == 106) ->
+      39.0 + (toFloat i)
+    | (i == 107) ->
+      38.0 + (toFloat i)
+    | (i == 108) ->
+      49.0 + (toFloat i)
+    | (i == 109) ->
+      59.0 + (toFloat i)
+    | (i == 110) ->
+      69.0 + (toFloat i)
+    | (i == 111) ->
+      39.0 + (toFloat i)
+    | (i == 115) ->
+      69.0 + (toFloat i)
+    | otherwise ->
+      toFloat i
+      
+      
+fewConditionFunction i =
+  if
+    | i <= 0 ->
+      30.0 + (toFloat i)
+    | (i == 104) ->
+      59.0 + (toFloat i)
+    | (i == 105) ->
+      69.0 + (toFloat i)
     | otherwise ->
       toFloat i
   
@@ -48,4 +74,8 @@ tailRecSum intList =
       
 manyConditionalSum intList = 
   List.foldr (\i sumSoFar -> sumSoFar + manyConditionFunction i ) 0.0 intList
+    
+    
+fewConditionalSum intList = 
+  List.foldr (\i sumSoFar -> sumSoFar + fewConditionFunction i ) 0.0 intList
     

--- a/bench/src/IfBench.elm
+++ b/bench/src/IfBench.elm
@@ -1,0 +1,51 @@
+module IfBench where
+
+tailRecursiveIfFn : Int -> Float
+tailRecursiveIfFn i = 
+  if 
+    | i < 0 ->
+      10.0
+    | i == 0 ->
+      20.0
+    | i > 0 && i < 10 ->
+      30.0
+    | otherwise ->
+      tailRecursiveIfFn (i - (1 + (i % 5 ) ) )
+    
+    
+manyConditionFunction i =
+  if
+    | i <= 0 ->
+      30.0 + (toFloat i)
+    | i > 100 && (i * i) % 20 == 7 ->
+      24.3 + (toFloat i)
+    | i > 100 && (i % 3 == 1) ->
+      3.33 + (toFloat i)
+    | (i == 152) ->
+      29.0 + (toFloat i)
+    | (i + (i*i) > 200 && (i + (i*i) < 300)) -> 
+      32.9 + (toFloat i)
+    | i == 99 ->
+      93.0 + (toFloat i)
+    | (i*i % 17 == 13 ) ->
+      9.0 + (toFloat i)
+    | (i == 101) ->
+      39.0 + (toFloat i)
+    | (i == 102) ->
+      38.0 + (toFloat i)
+    | (i == 103) ->
+      49.0 + (toFloat i)
+    | (i == 104) ->
+      59.0 + (toFloat i)
+    | (i == 105) ->
+      69.0 + (toFloat i)
+    | otherwise ->
+      toFloat i
+  
+  
+tailRecSum intList = 
+  List.foldr (\i sumSoFar -> sumSoFar + tailRecursiveIfFn i ) 0.0 intList  
+      
+manyConditionalSum intList = 
+  List.foldr (\i sumSoFar -> sumSoFar + manyConditionFunction i ) 0.0 intList
+    

--- a/bench/src/LargeDictionary.elm
+++ b/bench/src/LargeDictionary.elm
@@ -1,0 +1,34 @@
+module LargeDictionary where
+
+
+import Dict
+import Random
+import Signal
+import Time
+import Graphics.Element
+
+
+maxSize = 10000000
+
+
+randomGen =
+  Random.int (-1 * maxSize) (maxSize)
+
+
+addNToDictWithSeed 
+  :  Int 
+  -> Random.Seed 
+  -> Dict.Dict Int Int 
+  -> Dict.Dict Int Int
+addNToDictWithSeed n seed accum = 
+  case n of
+    0 -> accum
+    _ -> 
+      let
+        (nextToAdd, newSeed) = Random.generate randomGen seed
+        newAccum = Dict.insert nextToAdd nextToAdd accum
+      in addNToDictWithSeed (n-1) newSeed newAccum
+
+
+addNToDictAndSum numToInsert = 
+  addNToDictWithSeed numToInsert (Random.initialSeed 23) Dict.empty

--- a/bench/src/ListBench.elm
+++ b/bench/src/ListBench.elm
@@ -1,0 +1,65 @@
+module ListBench where
+
+import Random
+
+
+
+randomList 
+  :  Random.Generator a
+  -> Int 
+  -> Random.Seed 
+  -> List a
+randomList gen n initSeed =
+  let
+    f n (seed, accum) =
+      let
+        (nextToAdd, newSeed) = Random.generate gen seed
+        newAccum = nextToAdd :: accum
+      in (newSeed, newAccum)
+  in 
+    snd <| List.foldl f (initSeed, []) [1 .. n]
+
+meanAndStddev 
+  :  ((Float -> (Float, Float) -> (Float, Float)) -> (Float, Float) -> List Float -> (Float, Float)) 
+  -> List Float
+  -> (Float, Float)
+meanAndStddev foldFn ourList =
+  let 
+    --ourList = addNToListWithSeed n (Random.initialSeed 23)
+    (theSum, sumSq) = foldFn (\x (sum, sumSq) -> (x + sum, (x^2) + sumSq) ) (0,0) ourList
+  in
+    (theSum, sqrt(theSum*theSum - sumSq))
+    
+
+foldrMeanStddev = meanAndStddev List.foldr
+
+foldlMeanStddev = meanAndStddev List.foldl
+
+customFoldrMeanStddev = meanAndStddev myFoldr 
+
+customFoldlMeanStddev = meanAndStddev myFoldl
+
+
+randomLookups : List Int -> List Float -> List (Maybe Float)
+randomLookups indices ourList =
+  let
+    getNth i l = 
+      case (i, l) of
+        (_, []) -> Nothing
+        (0, x :: _) -> Just x
+        (i, _ :: xs ) -> getNth i xs 
+  in List.map (\i -> getNth i ourList) indices
+
+
+myFoldl : (a -> b -> b) -> b -> List a -> b
+myFoldl f init l = 
+  case l of
+    [] -> init
+    (x :: xs) -> myFoldl f (f x init) xs 
+
+
+myFoldr : (a -> b -> b) -> b -> List a -> b
+myFoldr f init l =
+  case l of
+    [] -> init
+    (x :: xs) -> f x (myFoldr f init xs)

--- a/bench/src/ListBench.elm
+++ b/bench/src/ListBench.elm
@@ -33,11 +33,26 @@ meanAndStddev foldFn ourList =
 
 foldrMeanStddev = meanAndStddev List.foldr
 
+
 foldlMeanStddev = meanAndStddev List.foldl
+
 
 customFoldrMeanStddev = meanAndStddev myFoldr 
 
+
 customFoldlMeanStddev = meanAndStddev myFoldl
+
+
+updateNRandomIndices
+  :  (Float -> Float)
+  -> List Int
+  -> List Float
+  -> List Float
+updateNRandomIndices f indexList startList = 
+  List.foldr 
+  (\ i oldList -> updateN i f oldList)
+  startList indexList
+  
 
 
 randomLookups : List Int -> List Float -> List (Maybe Float)
@@ -63,3 +78,8 @@ myFoldr f init l =
   case l of
     [] -> init
     (x :: xs) -> f x (myFoldr f init xs)
+    
+
+updateN : Int -> (a -> a) -> List a -> List a
+updateN n f list = 
+  List.indexedMap (\index value -> if index == n then f value else value) list    

--- a/bench/src/Native/Benchmark.js
+++ b/bench/src/Native/Benchmark.js
@@ -1,0 +1,102 @@
+Elm.Native.Benchmark = {};
+Elm.Native.Benchmark.make = function(localRuntime) {
+
+	localRuntime.Native = localRuntime.Native || {};
+	localRuntime.Native.Benchmark = localRuntime.Native.Benchmark || {};
+	if (localRuntime.Native.Benchmark.values)
+	{
+		return localRuntime.Native.Benchmark.values;
+	}
+
+	var List = Elm.Native.List.make(localRuntime);
+	var Task = Elm.Native.Task.make(localRuntime);
+        var Signal = Elm.Signal.make(localRuntime);
+        var Utils = Elm.Native.Utils.make(localRuntime);
+
+        //Nothing special happens here, but we need to use it as a Native function
+        //So that we can accept thunks of any type
+        function makeBenchmark(name, thunk)
+        {
+            return {name : name, thunk : thunk};
+        }
+
+        //Generate the task for running a benchmark suite
+        //Possibly updating a given mailbox with a string describing
+        //Our progress of running the benchmarks so far
+	function runWithProgress(maybeTaskFn, inSuite)
+	{
+            
+	    return Task.asyncFunction(function(callback) {
+                var bjsSuite = new Benchmark.Suite;
+                var benchArray;
+                var retData = [];
+                var finalString = "";
+                var numCompleted = 0;
+                var numToRun;
+                
+                switch (inSuite.ctor)
+                {
+                    case "Suite":
+                      benchArray = List.toArray(inSuite._1);
+                      break;
+                    case "SingleBenchmark":
+                      benchArray = [inSuite._0 ];
+                      break;
+                }
+
+                numToRun = benchArray.length;
+                Task.perform(maybeTaskFn("Running benchmark 1 of " + numToRun));
+
+                //Initialize each benchmark in the suite
+                for (i = 0; i < benchArray.length; i++)
+                {
+                    var ourThunk = function (){
+                        //Run the thing we're timing, then mark the asynch benchmark as done
+                        benchArray[i].thunk();
+                        deferred.resolve();
+                        }
+                    bjsSuite.add(benchArray[i].name, benchArray[i].thunk );
+                }
+
+                //Every time a benchmark finishes, we store its results
+                //and update our progress string
+                bjsSuite.on('cycle', function(event) {
+                   numCompleted += 1;
+                   retData.push(
+                       { name : event.target.options.name
+                       , hz : event.target.hz
+                       , marginOfError : event.target.stats.moe
+                       , moePercent : event.target.stats.rme
+                       }
+                       );
+                   finalString += String(event.target) + "\n";
+                   var intermedString = 
+                        "Running benchmark " 
+                        + (numCompleted + 1) 
+                        + " of " + numToRun 
+                        + "\nLast result: " + String(event.target);
+                   Task.perform(maybeTaskFn(intermedString));
+                   //retString += String(event.target) + "\n";
+                });
+                
+                //When the last benchmark finishes, we show all results collected
+                bjsSuite.on('complete', function(event) {
+                   Task.perform(maybeTaskFn("Final results:\n\n" + finalString) );
+                   return callback(Task.succeed(Utils.Tuple2(finalString, List.fromArray(retData))));
+                });
+
+                //Finally: actually run the suite
+                Task.perform(
+                  Task.asyncFunction(function(otherCallback){
+                      bjsSuite.run({ 'async': true });
+                  }));
+        });
+             }
+
+	return localRuntime.Native.Benchmark.values = {
+		makeBenchmark: F2(makeBenchmark),
+		runWithProgress: F2(runWithProgress)
+	};
+                
+   
+};

--- a/bench/src/Native/BenchmarkJS.js
+++ b/bench/src/Native/BenchmarkJS.js
@@ -1,0 +1,3919 @@
+/*!
+ * Benchmark.js v1.0.0 <http://benchmarkjs.com/>
+ * Copyright 2010-2012 Mathias Bynens <http://mths.be/>
+ * Based on JSLitmus.js, copyright Robert Kieffer <http://broofa.com/>
+ * Modified by John-David Dalton <http://allyoucanleet.com/>
+ * Available under MIT license <http://mths.be/mit>
+ */
+;(function(window, undefined) {
+  'use strict';
+
+  /** Used to assign each benchmark an incrimented id */
+  var counter = 0;
+
+  /** Detect DOM document object */
+  var doc = isHostType(window, 'document') && document;
+
+  /** Detect free variable `define` */
+  var freeDefine = typeof define == 'function' &&
+    typeof define.amd == 'object' && define.amd && define;
+
+  /** Detect free variable `exports` */
+  var freeExports = typeof exports == 'object' && exports &&
+    (typeof global == 'object' && global && global == global.global && (window = global), exports);
+
+  /** Detect free variable `require` */
+  var freeRequire = typeof require == 'function' && require;
+
+  /** Used to crawl all properties regardless of enumerability */
+  var getAllKeys = Object.getOwnPropertyNames;
+
+  /** Used to get property descriptors */
+  var getDescriptor = Object.getOwnPropertyDescriptor;
+
+  /** Used in case an object doesn't have its own method */
+  var hasOwnProperty = {}.hasOwnProperty;
+
+  /** Used to check if an object is extensible */
+  var isExtensible = Object.isExtensible || function() { return true; };
+
+  /** Used to access Wade Simmons' Node microtime module */
+  var microtimeObject = req('microtime');
+
+  /** Used to access the browser's high resolution timer */
+  var perfObject = isHostType(window, 'performance') && performance;
+
+  /** Used to call the browser's high resolution timer */
+  var perfName = perfObject && (
+    perfObject.now && 'now' ||
+    perfObject.webkitNow && 'webkitNow'
+  );
+
+  /** Used to access Node's high resolution timer */
+  var processObject = isHostType(window, 'process') && process;
+
+  /** Used to check if an own property is enumerable */
+  var propertyIsEnumerable = {}.propertyIsEnumerable;
+
+  /** Used to set property descriptors */
+  var setDescriptor = Object.defineProperty;
+
+  /** Used to resolve a value's internal [[Class]] */
+  var toString = {}.toString;
+
+  /** Used to prevent a `removeChild` memory leak in IE < 9 */
+  var trash = doc && doc.createElement('div');
+
+  /** Used to integrity check compiled tests */
+  var uid = 'uid' + (+new Date);
+
+  /** Used to avoid infinite recursion when methods call each other */
+  var calledBy = {};
+
+  /** Used to avoid hz of Infinity */
+  var divisors = {
+    '1': 4096,
+    '2': 512,
+    '3': 64,
+    '4': 8,
+    '5': 0
+  };
+
+  /**
+   * T-Distribution two-tailed critical values for 95% confidence
+   * http://www.itl.nist.gov/div898/handbook/eda/section3/eda3672.htm
+   */
+  var tTable = {
+    '1':  12.706,'2':  4.303, '3':  3.182, '4':  2.776, '5':  2.571, '6':  2.447,
+    '7':  2.365, '8':  2.306, '9':  2.262, '10': 2.228, '11': 2.201, '12': 2.179,
+    '13': 2.16,  '14': 2.145, '15': 2.131, '16': 2.12,  '17': 2.11,  '18': 2.101,
+    '19': 2.093, '20': 2.086, '21': 2.08,  '22': 2.074, '23': 2.069, '24': 2.064,
+    '25': 2.06,  '26': 2.056, '27': 2.052, '28': 2.048, '29': 2.045, '30': 2.042,
+    'infinity': 1.96
+  };
+
+  /**
+   * Critical Mann-Whitney U-values for 95% confidence
+   * http://www.saburchill.com/IBbiology/stats/003.html
+   */
+  var uTable = {
+    '5':  [0, 1, 2],
+    '6':  [1, 2, 3, 5],
+    '7':  [1, 3, 5, 6, 8],
+    '8':  [2, 4, 6, 8, 10, 13],
+    '9':  [2, 4, 7, 10, 12, 15, 17],
+    '10': [3, 5, 8, 11, 14, 17, 20, 23],
+    '11': [3, 6, 9, 13, 16, 19, 23, 26, 30],
+    '12': [4, 7, 11, 14, 18, 22, 26, 29, 33, 37],
+    '13': [4, 8, 12, 16, 20, 24, 28, 33, 37, 41, 45],
+    '14': [5, 9, 13, 17, 22, 26, 31, 36, 40, 45, 50, 55],
+    '15': [5, 10, 14, 19, 24, 29, 34, 39, 44, 49, 54, 59, 64],
+    '16': [6, 11, 15, 21, 26, 31, 37, 42, 47, 53, 59, 64, 70, 75],
+    '17': [6, 11, 17, 22, 28, 34, 39, 45, 51, 57, 63, 67, 75, 81, 87],
+    '18': [7, 12, 18, 24, 30, 36, 42, 48, 55, 61, 67, 74, 80, 86, 93, 99],
+    '19': [7, 13, 19, 25, 32, 38, 45, 52, 58, 65, 72, 78, 85, 92, 99, 106, 113],
+    '20': [8, 14, 20, 27, 34, 41, 48, 55, 62, 69, 76, 83, 90, 98, 105, 112, 119, 127],
+    '21': [8, 15, 22, 29, 36, 43, 50, 58, 65, 73, 80, 88, 96, 103, 111, 119, 126, 134, 142],
+    '22': [9, 16, 23, 30, 38, 45, 53, 61, 69, 77, 85, 93, 101, 109, 117, 125, 133, 141, 150, 158],
+    '23': [9, 17, 24, 32, 40, 48, 56, 64, 73, 81, 89, 98, 106, 115, 123, 132, 140, 149, 157, 166, 175],
+    '24': [10, 17, 25, 33, 42, 50, 59, 67, 76, 85, 94, 102, 111, 120, 129, 138, 147, 156, 165, 174, 183, 192],
+    '25': [10, 18, 27, 35, 44, 53, 62, 71, 80, 89, 98, 107, 117, 126, 135, 145, 154, 163, 173, 182, 192, 201, 211],
+    '26': [11, 19, 28, 37, 46, 55, 64, 74, 83, 93, 102, 112, 122, 132, 141, 151, 161, 171, 181, 191, 200, 210, 220, 230],
+    '27': [11, 20, 29, 38, 48, 57, 67, 77, 87, 97, 107, 118, 125, 138, 147, 158, 168, 178, 188, 199, 209, 219, 230, 240, 250],
+    '28': [12, 21, 30, 40, 50, 60, 70, 80, 90, 101, 111, 122, 132, 143, 154, 164, 175, 186, 196, 207, 218, 228, 239, 250, 261, 272],
+    '29': [13, 22, 32, 42, 52, 62, 73, 83, 94, 105, 116, 127, 138, 149, 160, 171, 182, 193, 204, 215, 226, 238, 249, 260, 271, 282, 294],
+    '30': [13, 23, 33, 43, 54, 65, 76, 87, 98, 109, 120, 131, 143, 154, 166, 177, 189, 200, 212, 223, 235, 247, 258, 270, 282, 293, 305, 317]
+  };
+
+  /**
+   * An object used to flag environments/features.
+   *
+   * @static
+   * @memberOf Benchmark
+   * @type Object
+   */
+  var support = {};
+
+  (function() {
+
+    /**
+     * Detect Adobe AIR.
+     *
+     * @memberOf Benchmark.support
+     * @type Boolean
+     */
+    support.air = isClassOf(window.runtime, 'ScriptBridgingProxyObject');
+
+    /**
+     * Detect if `arguments` objects have the correct internal [[Class]] value.
+     *
+     * @memberOf Benchmark.support
+     * @type Boolean
+     */
+    support.argumentsClass = isClassOf(arguments, 'Arguments');
+
+    /**
+     * Detect if in a browser environment.
+     *
+     * @memberOf Benchmark.support
+     * @type Boolean
+     */
+    support.browser = doc && isHostType(window, 'navigator');
+
+    /**
+     * Detect if strings support accessing characters by index.
+     *
+     * @memberOf Benchmark.support
+     * @type Boolean
+     */
+    support.charByIndex =
+      // IE 8 supports indexes on string literals but not string objects
+      ('x'[0] + Object('x')[0]) == 'xx';
+
+    /**
+     * Detect if strings have indexes as own properties.
+     *
+     * @memberOf Benchmark.support
+     * @type Boolean
+     */
+    support.charByOwnIndex =
+      // Narwhal, Rhino, RingoJS, IE 8, and Opera < 10.52 support indexes on
+      // strings but don't detect them as own properties
+      support.charByIndex && hasKey('x', '0');
+
+    /**
+     * Detect if Java is enabled/exposed.
+     *
+     * @memberOf Benchmark.support
+     * @type Boolean
+     */
+    support.java = isClassOf(window.java, 'JavaPackage');
+
+    /**
+     * Detect if the Timers API exists.
+     *
+     * @memberOf Benchmark.support
+     * @type Boolean
+     */
+    support.timeout = isHostType(window, 'setTimeout') && isHostType(window, 'clearTimeout');
+
+    /**
+     * Detect if functions support decompilation.
+     *
+     * @name decompilation
+     * @memberOf Benchmark.support
+     * @type Boolean
+     */
+    try {
+      // Safari 2.x removes commas in object literals
+      // from Function#toString results
+      // http://webk.it/11609
+      // Firefox 3.6 and Opera 9.25 strip grouping
+      // parentheses from Function#toString results
+      // http://bugzil.la/559438
+      support.decompilation = Function(
+        'return (' + (function(x) { return { 'x': '' + (1 + x) + '', 'y': 0 }; }) + ')'
+      )()(0).x === '1';
+    } catch(e) {
+      support.decompilation = false;
+    }
+
+    /**
+     * Detect ES5+ property descriptor API.
+     *
+     * @name descriptors
+     * @memberOf Benchmark.support
+     * @type Boolean
+     */
+    try {
+      var o = {};
+      support.descriptors = (setDescriptor(o, o, o), 'value' in getDescriptor(o, o));
+    } catch(e) {
+      support.descriptors = false;
+    }
+
+    /**
+     * Detect ES5+ Object.getOwnPropertyNames().
+     *
+     * @name getAllKeys
+     * @memberOf Benchmark.support
+     * @type Boolean
+     */
+    try {
+      support.getAllKeys = /\bvalueOf\b/.test(getAllKeys(Object.prototype));
+    } catch(e) {
+      support.getAllKeys = false;
+    }
+
+    /**
+     * Detect if own properties are iterated before inherited properties (all but IE < 9).
+     *
+     * @name iteratesOwnLast
+     * @memberOf Benchmark.support
+     * @type Boolean
+     */
+    support.iteratesOwnFirst = (function() {
+      var props = [];
+      function ctor() { this.x = 1; }
+      ctor.prototype = { 'y': 1 };
+      for (var prop in new ctor) { props.push(prop); }
+      return props[0] == 'x';
+    }());
+
+    /**
+     * Detect if a node's [[Class]] is resolvable (all but IE < 9)
+     * and that the JS engine errors when attempting to coerce an object to a
+     * string without a `toString` property value of `typeof` "function".
+     *
+     * @name nodeClass
+     * @memberOf Benchmark.support
+     * @type Boolean
+     */
+    try {
+      support.nodeClass = ({ 'toString': 0 } + '', toString.call(doc || 0) != '[object Object]');
+    } catch(e) {
+      support.nodeClass = true;
+    }
+  }());
+
+  /**
+   * Timer object used by `clock()` and `Deferred#resolve`.
+   *
+   * @private
+   * @type Object
+   */
+  var timer = {
+
+   /**
+    * The timer namespace object or constructor.
+    *
+    * @private
+    * @memberOf timer
+    * @type Function|Object
+    */
+    'ns': Date,
+
+   /**
+    * Starts the deferred timer.
+    *
+    * @private
+    * @memberOf timer
+    * @param {Object} deferred The deferred instance.
+    */
+    'start': null, // lazy defined in `clock()`
+
+   /**
+    * Stops the deferred timer.
+    *
+    * @private
+    * @memberOf timer
+    * @param {Object} deferred The deferred instance.
+    */
+    'stop': null // lazy defined in `clock()`
+  };
+
+  /** Shortcut for inverse results */
+  var noArgumentsClass = !support.argumentsClass,
+      noCharByIndex = !support.charByIndex,
+      noCharByOwnIndex = !support.charByOwnIndex;
+
+  /** Math shortcuts */
+  var abs   = Math.abs,
+      floor = Math.floor,
+      max   = Math.max,
+      min   = Math.min,
+      pow   = Math.pow,
+      sqrt  = Math.sqrt;
+
+  /*--------------------------------------------------------------------------*/
+
+  /**
+   * The Benchmark constructor.
+   *
+   * @constructor
+   * @param {String} name A name to identify the benchmark.
+   * @param {Function|String} fn The test to benchmark.
+   * @param {Object} [options={}] Options object.
+   * @example
+   *
+   * // basic usage (the `new` operator is optional)
+   * var bench = new Benchmark(fn);
+   *
+   * // or using a name first
+   * var bench = new Benchmark('foo', fn);
+   *
+   * // or with options
+   * var bench = new Benchmark('foo', fn, {
+   *
+   *   // displayed by Benchmark#toString if `name` is not available
+   *   'id': 'xyz',
+   *
+   *   // called when the benchmark starts running
+   *   'onStart': onStart,
+   *
+   *   // called after each run cycle
+   *   'onCycle': onCycle,
+   *
+   *   // called when aborted
+   *   'onAbort': onAbort,
+   *
+   *   // called when a test errors
+   *   'onError': onError,
+   *
+   *   // called when reset
+   *   'onReset': onReset,
+   *
+   *   // called when the benchmark completes running
+   *   'onComplete': onComplete,
+   *
+   *   // compiled/called before the test loop
+   *   'setup': setup,
+   *
+   *   // compiled/called after the test loop
+   *   'teardown': teardown
+   * });
+   *
+   * // or name and options
+   * var bench = new Benchmark('foo', {
+   *
+   *   // a flag to indicate the benchmark is deferred
+   *   'defer': true,
+   *
+   *   // benchmark test function
+   *   'fn': function(deferred) {
+   *     // call resolve() when the deferred test is finished
+   *     deferred.resolve();
+   *   }
+   * });
+   *
+   * // or options only
+   * var bench = new Benchmark({
+   *
+   *   // benchmark name
+   *   'name': 'foo',
+   *
+   *   // benchmark test as a string
+   *   'fn': '[1,2,3,4].sort()'
+   * });
+   *
+   * // a test's `this` binding is set to the benchmark instance
+   * var bench = new Benchmark('foo', function() {
+   *   'My name is '.concat(this.name); // My name is foo
+   * });
+   */
+  function Benchmark(name, fn, options) {
+    var me = this;
+
+    // allow instance creation without the `new` operator
+    if (me == null || me.constructor != Benchmark) {
+      return new Benchmark(name, fn, options);
+    }
+    // juggle arguments
+    if (isClassOf(name, 'Object')) {
+      // 1 argument (options)
+      options = name;
+    }
+    else if (isClassOf(name, 'Function')) {
+      // 2 arguments (fn, options)
+      options = fn;
+      fn = name;
+    }
+    else if (isClassOf(fn, 'Object')) {
+      // 2 arguments (name, options)
+      options = fn;
+      fn = null;
+      me.name = name;
+    }
+    else {
+      // 3 arguments (name, fn [, options])
+      me.name = name;
+    }
+    setOptions(me, options);
+    me.id || (me.id = ++counter);
+    me.fn == null && (me.fn = fn);
+    me.stats = deepClone(me.stats);
+    me.times = deepClone(me.times);
+  }
+
+  /**
+   * The Deferred constructor.
+   *
+   * @constructor
+   * @memberOf Benchmark
+   * @param {Object} clone The cloned benchmark instance.
+   */
+  function Deferred(clone) {
+    var me = this;
+    if (me == null || me.constructor != Deferred) {
+      return new Deferred(clone);
+    }
+    me.benchmark = clone;
+    clock(me);
+  }
+
+  /**
+   * The Event constructor.
+   *
+   * @constructor
+   * @memberOf Benchmark
+   * @param {String|Object} type The event type.
+   */
+  function Event(type) {
+    var me = this;
+    return (me == null || me.constructor != Event)
+      ? new Event(type)
+      : (type instanceof Event)
+          ? type
+          : extend(me, { 'timeStamp': +new Date }, typeof type == 'string' ? { 'type': type } : type);
+  }
+
+  /**
+   * The Suite constructor.
+   *
+   * @constructor
+   * @memberOf Benchmark
+   * @param {String} name A name to identify the suite.
+   * @param {Object} [options={}] Options object.
+   * @example
+   *
+   * // basic usage (the `new` operator is optional)
+   * var suite = new Benchmark.Suite;
+   *
+   * // or using a name first
+   * var suite = new Benchmark.Suite('foo');
+   *
+   * // or with options
+   * var suite = new Benchmark.Suite('foo', {
+   *
+   *   // called when the suite starts running
+   *   'onStart': onStart,
+   *
+   *   // called between running benchmarks
+   *   'onCycle': onCycle,
+   *
+   *   // called when aborted
+   *   'onAbort': onAbort,
+   *
+   *   // called when a test errors
+   *   'onError': onError,
+   *
+   *   // called when reset
+   *   'onReset': onReset,
+   *
+   *   // called when the suite completes running
+   *   'onComplete': onComplete
+   * });
+   */
+  function Suite(name, options) {
+    var me = this;
+
+    // allow instance creation without the `new` operator
+    if (me == null || me.constructor != Suite) {
+      return new Suite(name, options);
+    }
+    // juggle arguments
+    if (isClassOf(name, 'Object')) {
+      // 1 argument (options)
+      options = name;
+    } else {
+      // 2 arguments (name [, options])
+      me.name = name;
+    }
+    setOptions(me, options);
+  }
+
+  /*--------------------------------------------------------------------------*/
+
+  /**
+   * Note: Some array methods have been implemented in plain JavaScript to avoid
+   * bugs in IE, Opera, Rhino, and Mobile Safari.
+   *
+   * IE compatibility mode and IE < 9 have buggy Array `shift()` and `splice()`
+   * functions that fail to remove the last element, `object[0]`, of
+   * array-like-objects even though the `length` property is set to `0`.
+   * The `shift()` method is buggy in IE 8 compatibility mode, while `splice()`
+   * is buggy regardless of mode in IE < 9 and buggy in compatibility mode in IE 9.
+   *
+   * In Opera < 9.50 and some older/beta Mobile Safari versions using `unshift()`
+   * generically to augment the `arguments` object will pave the value at index 0
+   * without incrimenting the other values's indexes.
+   * https://github.com/documentcloud/underscore/issues/9
+   *
+   * Rhino and environments it powers, like Narwhal and RingoJS, may have
+   * buggy Array `concat()`, `reverse()`, `shift()`, `slice()`, `splice()` and
+   * `unshift()` functions that make sparse arrays non-sparse by assigning the
+   * undefined indexes a value of undefined.
+   * https://github.com/mozilla/rhino/commit/702abfed3f8ca043b2636efd31c14ba7552603dd
+   */
+
+  /**
+   * Creates an array containing the elements of the host array followed by the
+   * elements of each argument in order.
+   *
+   * @memberOf Benchmark.Suite
+   * @returns {Array} The new array.
+   */
+  function concat() {
+    var value,
+        j = -1,
+        length = arguments.length,
+        result = slice.call(this),
+        index = result.length;
+
+    while (++j < length) {
+      value = arguments[j];
+      if (isClassOf(value, 'Array')) {
+        for (var k = 0, l = value.length; k < l; k++, index++) {
+          if (k in value) {
+            result[index] = value[k];
+          }
+        }
+      } else {
+        result[index++] = value;
+      }
+    }
+    return result;
+  }
+
+  /**
+   * Utility function used by `shift()`, `splice()`, and `unshift()`.
+   *
+   * @private
+   * @param {Number} start The index to start inserting elements.
+   * @param {Number} deleteCount The number of elements to delete from the insert point.
+   * @param {Array} elements The elements to insert.
+   * @returns {Array} An array of deleted elements.
+   */
+  function insert(start, deleteCount, elements) {
+    // `result` should have its length set to the `deleteCount`
+    // see https://bugs.ecmascript.org/show_bug.cgi?id=332
+    var deleteEnd = start + deleteCount,
+        elementCount = elements ? elements.length : 0,
+        index = start - 1,
+        length = start + elementCount,
+        object = this,
+        result = Array(deleteCount),
+        tail = slice.call(object, deleteEnd);
+
+    // delete elements from the array
+    while (++index < deleteEnd) {
+      if (index in object) {
+        result[index - start] = object[index];
+        delete object[index];
+      }
+    }
+    // insert elements
+    index = start - 1;
+    while (++index < length) {
+      object[index] = elements[index - start];
+    }
+    // append tail elements
+    start = index--;
+    length = max(0, (object.length >>> 0) - deleteCount + elementCount);
+    while (++index < length) {
+      if ((index - start) in tail) {
+        object[index] = tail[index - start];
+      } else if (index in object) {
+        delete object[index];
+      }
+    }
+    // delete excess elements
+    deleteCount = deleteCount > elementCount ? deleteCount - elementCount : 0;
+    while (deleteCount--) {
+      index = length + deleteCount;
+      if (index in object) {
+        delete object[index];
+      }
+    }
+    object.length = length;
+    return result;
+  }
+
+  /**
+   * Rearrange the host array's elements in reverse order.
+   *
+   * @memberOf Benchmark.Suite
+   * @returns {Array} The reversed array.
+   */
+  function reverse() {
+    var upperIndex,
+        value,
+        index = -1,
+        object = Object(this),
+        length = object.length >>> 0,
+        middle = floor(length / 2);
+
+    if (length > 1) {
+      while (++index < middle) {
+        upperIndex = length - index - 1;
+        value = upperIndex in object ? object[upperIndex] : uid;
+        if (index in object) {
+          object[upperIndex] = object[index];
+        } else {
+          delete object[upperIndex];
+        }
+        if (value != uid) {
+          object[index] = value;
+        } else {
+          delete object[index];
+        }
+      }
+    }
+    return object;
+  }
+
+  /**
+   * Removes the first element of the host array and returns it.
+   *
+   * @memberOf Benchmark.Suite
+   * @returns {Mixed} The first element of the array.
+   */
+  function shift() {
+    return insert.call(this, 0, 1)[0];
+  }
+
+  /**
+   * Creates an array of the host array's elements from the start index up to,
+   * but not including, the end index.
+   *
+   * @memberOf Benchmark.Suite
+   * @param {Number} start The starting index.
+   * @param {Number} end The end index.
+   * @returns {Array} The new array.
+   */
+  function slice(start, end) {
+    var index = -1,
+        object = Object(this),
+        length = object.length >>> 0,
+        result = [];
+
+    start = toInteger(start);
+    start = start < 0 ? max(length + start, 0) : min(start, length);
+    start--;
+    end = end == null ? length : toInteger(end);
+    end = end < 0 ? max(length + end, 0) : min(end, length);
+
+    while ((++index, ++start) < end) {
+      if (start in object) {
+        result[index] = object[start];
+      }
+    }
+    return result;
+  }
+
+  /**
+   * Allows removing a range of elements and/or inserting elements into the
+   * host array.
+   *
+   * @memberOf Benchmark.Suite
+   * @param {Number} start The start index.
+   * @param {Number} deleteCount The number of elements to delete.
+   * @param {Mixed} [val1, val2, ...] values to insert at the `start` index.
+   * @returns {Array} An array of removed elements.
+   */
+  function splice(start, deleteCount) {
+    var object = Object(this),
+        length = object.length >>> 0;
+
+    start = toInteger(start);
+    start = start < 0 ? max(length + start, 0) : min(start, length);
+
+    // support the de-facto SpiderMonkey extension
+    // https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Array/splice#Parameters
+    // https://bugs.ecmascript.org/show_bug.cgi?id=429
+    deleteCount = arguments.length == 1
+      ? length - start
+      : min(max(toInteger(deleteCount), 0), length - start);
+
+    return insert.call(object, start, deleteCount, slice.call(arguments, 2));
+  }
+
+  /**
+   * Converts the specified `value` to an integer.
+   *
+   * @private
+   * @param {Mixed} value The value to convert.
+   * @returns {Number} The resulting integer.
+   */
+  function toInteger(value) {
+    value = +value;
+    return value === 0 || !isFinite(value) ? value || 0 : value - (value % 1);
+  }
+
+  /**
+   * Appends arguments to the host array.
+   *
+   * @memberOf Benchmark.Suite
+   * @returns {Number} The new length.
+   */
+  function unshift() {
+    var object = Object(this);
+    insert.call(object, 0, 0, arguments);
+    return object.length;
+  }
+
+  /*--------------------------------------------------------------------------*/
+
+  /**
+   * A generic `Function#bind` like method.
+   *
+   * @private
+   * @param {Function} fn The function to be bound to `thisArg`.
+   * @param {Mixed} thisArg The `this` binding for the given function.
+   * @returns {Function} The bound function.
+   */
+  function bind(fn, thisArg) {
+    return function() { fn.apply(thisArg, arguments); };
+  }
+
+  /**
+   * Creates a function from the given arguments string and body.
+   *
+   * @private
+   * @param {String} args The comma separated function arguments.
+   * @param {String} body The function body.
+   * @returns {Function} The new function.
+   */
+  function createFunction() {
+    // lazy define
+    createFunction = function(args, body) {
+      var result,
+          anchor = freeDefine ? define.amd : Benchmark,
+          prop = uid + 'createFunction';
+
+      runScript((freeDefine ? 'define.amd.' : 'Benchmark.') + prop + '=function(' + args + '){' + body + '}');
+      result = anchor[prop];
+      delete anchor[prop];
+      return result;
+    };
+    // fix JaegerMonkey bug
+    // http://bugzil.la/639720
+    createFunction = support.browser && (createFunction('', 'return"' + uid + '"') || noop)() == uid ? createFunction : Function;
+    return createFunction.apply(null, arguments);
+  }
+
+  /**
+   * Delay the execution of a function based on the benchmark's `delay` property.
+   *
+   * @private
+   * @param {Object} bench The benchmark instance.
+   * @param {Object} fn The function to execute.
+   */
+  function delay(bench, fn) {
+    bench._timerId = setTimeout(fn, bench.delay * 1e3);
+  }
+
+  /**
+   * Destroys the given element.
+   *
+   * @private
+   * @param {Element} element The element to destroy.
+   */
+  function destroyElement(element) {
+    trash.appendChild(element);
+    trash.innerHTML = '';
+  }
+
+  /**
+   * Iterates over an object's properties, executing the `callback` for each.
+   * Callbacks may terminate the loop by explicitly returning `false`.
+   *
+   * @private
+   * @param {Object} object The object to iterate over.
+   * @param {Function} callback The function executed per own property.
+   * @param {Object} options The options object.
+   * @returns {Object} Returns the object iterated over.
+   */
+  function forProps() {
+    var forShadowed,
+        skipSeen,
+        forArgs = true,
+        shadowed = ['constructor', 'hasOwnProperty', 'isPrototypeOf', 'propertyIsEnumerable', 'toLocaleString', 'toString', 'valueOf'];
+
+    (function(enumFlag, key) {
+      // must use a non-native constructor to catch the Safari 2 issue
+      function Klass() { this.valueOf = 0; };
+      Klass.prototype.valueOf = 0;
+      // check various for-in bugs
+      for (key in new Klass) {
+        enumFlag += key == 'valueOf' ? 1 : 0;
+      }
+      // check if `arguments` objects have non-enumerable indexes
+      for (key in arguments) {
+        key == '0' && (forArgs = false);
+      }
+      // Safari 2 iterates over shadowed properties twice
+      // http://replay.waybackmachine.org/20090428222941/http://tobielangel.com/2007/1/29/for-in-loop-broken-in-safari/
+      skipSeen = enumFlag == 2;
+      // IE < 9 incorrectly makes an object's properties non-enumerable if they have
+      // the same name as other non-enumerable properties in its prototype chain.
+      forShadowed = !enumFlag;
+    }(0));
+
+    // lazy define
+    forProps = function(object, callback, options) {
+      options || (options = {});
+
+      var result = object;
+      object = Object(object);
+
+      var ctor,
+          key,
+          keys,
+          skipCtor,
+          done = !result,
+          which = options.which,
+          allFlag = which == 'all',
+          index = -1,
+          iteratee = object,
+          length = object.length,
+          ownFlag = allFlag || which == 'own',
+          seen = {},
+          skipProto = isClassOf(object, 'Function'),
+          thisArg = options.bind;
+
+      if (thisArg !== undefined) {
+        callback = bind(callback, thisArg);
+      }
+      // iterate all properties
+      if (allFlag && support.getAllKeys) {
+        for (index = 0, keys = getAllKeys(object), length = keys.length; index < length; index++) {
+          key = keys[index];
+          if (callback(object[key], key, object) === false) {
+            break;
+          }
+        }
+      }
+      // else iterate only enumerable properties
+      else {
+        for (key in object) {
+          // Firefox < 3.6, Opera > 9.50 - Opera < 11.60, and Safari < 5.1
+          // (if the prototype or a property on the prototype has been set)
+          // incorrectly set a function's `prototype` property [[Enumerable]] value
+          // to `true`. Because of this we standardize on skipping the `prototype`
+          // property of functions regardless of their [[Enumerable]] value.
+          if ((done =
+              !(skipProto && key == 'prototype') &&
+              !(skipSeen && (hasKey(seen, key) || !(seen[key] = true))) &&
+              (!ownFlag || ownFlag && hasKey(object, key)) &&
+              callback(object[key], key, object) === false)) {
+            break;
+          }
+        }
+        // in IE < 9 strings don't support accessing characters by index
+        if (!done && (forArgs && isArguments(object) ||
+            ((noCharByIndex || noCharByOwnIndex) && isClassOf(object, 'String') &&
+              (iteratee = noCharByIndex ? object.split('') : object)))) {
+          while (++index < length) {
+            if ((done =
+                callback(iteratee[index], String(index), object) === false)) {
+              break;
+            }
+          }
+        }
+        if (!done && forShadowed) {
+          // Because IE < 9 can't set the `[[Enumerable]]` attribute of an existing
+          // property and the `constructor` property of a prototype defaults to
+          // non-enumerable, we manually skip the `constructor` property when we
+          // think we are iterating over a `prototype` object.
+          ctor = object.constructor;
+          skipCtor = ctor && ctor.prototype && ctor.prototype.constructor === ctor;
+          for (index = 0; index < 7; index++) {
+            key = shadowed[index];
+            if (!(skipCtor && key == 'constructor') &&
+                hasKey(object, key) &&
+                callback(object[key], key, object) === false) {
+              break;
+            }
+          }
+        }
+      }
+      return result;
+    };
+    return forProps.apply(null, arguments);
+  }
+
+  /**
+   * Gets the name of the first argument from a function's source.
+   *
+   * @private
+   * @param {Function} fn The function.
+   * @returns {String} The argument name.
+   */
+  function getFirstArgument(fn) {
+    return (!hasKey(fn, 'toString') &&
+      (/^[\s(]*function[^(]*\(([^\s,)]+)/.exec(fn) || 0)[1]) || '';
+  }
+
+  /**
+   * Computes the arithmetic mean of a sample.
+   *
+   * @private
+   * @param {Array} sample The sample.
+   * @returns {Number} The mean.
+   */
+  function getMean(sample) {
+    return reduce(sample, function(sum, x) {
+      return sum + x;
+    }) / sample.length || 0;
+  }
+
+  /**
+   * Gets the source code of a function.
+   *
+   * @private
+   * @param {Function} fn The function.
+   * @param {String} altSource A string used when a function's source code is unretrievable.
+   * @returns {String} The function's source code.
+   */
+  function getSource(fn, altSource) {
+    var result = altSource;
+    if (isStringable(fn)) {
+      result = String(fn);
+    } else if (support.decompilation) {
+      // escape the `{` for Firefox 1
+      result = (/^[^{]+\{([\s\S]*)}\s*$/.exec(fn) || 0)[1];
+    }
+    // trim string
+    result = (result || '').replace(/^\s+|\s+$/g, '');
+
+    // detect strings containing only the "use strict" directive
+    return /^(?:\/\*+[\w|\W]*?\*\/|\/\/.*?[\n\r\u2028\u2029]|\s)*(["'])use strict\1;?$/.test(result)
+      ? ''
+      : result;
+  }
+
+  /**
+   * Checks if a value is an `arguments` object.
+   *
+   * @private
+   * @param {Mixed} value The value to check.
+   * @returns {Boolean} Returns `true` if the value is an `arguments` object, else `false`.
+   */
+  function isArguments() {
+    // lazy define
+    isArguments = function(value) {
+      return toString.call(value) == '[object Arguments]';
+    };
+    if (noArgumentsClass) {
+      isArguments = function(value) {
+        return hasKey(value, 'callee') &&
+          !(propertyIsEnumerable && propertyIsEnumerable.call(value, 'callee'));
+      };
+    }
+    return isArguments(arguments[0]);
+  }
+
+  /**
+   * Checks if an object is of the specified class.
+   *
+   * @private
+   * @param {Mixed} value The value to check.
+   * @param {String} name The name of the class.
+   * @returns {Boolean} Returns `true` if the value is of the specified class, else `false`.
+   */
+  function isClassOf(value, name) {
+    return value != null && toString.call(value) == '[object ' + name + ']';
+  }
+
+  /**
+   * Host objects can return type values that are different from their actual
+   * data type. The objects we are concerned with usually return non-primitive
+   * types of object, function, or unknown.
+   *
+   * @private
+   * @param {Mixed} object The owner of the property.
+   * @param {String} property The property to check.
+   * @returns {Boolean} Returns `true` if the property value is a non-primitive, else `false`.
+   */
+  function isHostType(object, property) {
+    var type = object != null ? typeof object[property] : 'number';
+    return !/^(?:boolean|number|string|undefined)$/.test(type) &&
+      (type == 'object' ? !!object[property] : true);
+  }
+
+  /**
+   * Checks if a given `value` is an object created by the `Object` constructor
+   * assuming objects created by the `Object` constructor have no inherited
+   * enumerable properties and that there are no `Object.prototype` extensions.
+   *
+   * @private
+   * @param {Mixed} value The value to check.
+   * @returns {Boolean} Returns `true` if the `value` is a plain `Object` object, else `false`.
+   */
+  function isPlainObject(value) {
+    // avoid non-objects and false positives for `arguments` objects in IE < 9
+    var result = false;
+    if (!(value && typeof value == 'object') || isArguments(value)) {
+      return result;
+    }
+    // IE < 9 presents DOM nodes as `Object` objects except they have `toString`
+    // methods that are `typeof` "string" and still can coerce nodes to strings.
+    // Also check that the constructor is `Object` (i.e. `Object instanceof Object`)
+    var ctor = value.constructor;
+    if ((support.nodeClass || !(typeof value.toString != 'function' && typeof (value + '') == 'string')) &&
+        (!isClassOf(ctor, 'Function') || ctor instanceof ctor)) {
+      // In most environments an object's own properties are iterated before
+      // its inherited properties. If the last iterated property is an object's
+      // own property then there are no inherited enumerable properties.
+      if (support.iteratesOwnFirst) {
+        forProps(value, function(subValue, subKey) {
+          result = subKey;
+        });
+        return result === false || hasKey(value, result);
+      }
+      // IE < 9 iterates inherited properties before own properties. If the first
+      // iterated property is an object's own property then there are no inherited
+      // enumerable properties.
+      forProps(value, function(subValue, subKey) {
+        result = !hasKey(value, subKey);
+        return false;
+      });
+      return result === false;
+    }
+    return result;
+  }
+
+  /**
+   * Checks if a value can be safely coerced to a string.
+   *
+   * @private
+   * @param {Mixed} value The value to check.
+   * @returns {Boolean} Returns `true` if the value can be coerced, else `false`.
+   */
+  function isStringable(value) {
+    return hasKey(value, 'toString') || isClassOf(value, 'String');
+  }
+
+  /**
+   * Wraps a function and passes `this` to the original function as the
+   * first argument.
+   *
+   * @private
+   * @param {Function} fn The function to be wrapped.
+   * @returns {Function} The new function.
+   */
+  function methodize(fn) {
+    return function() {
+      var args = [this];
+      args.push.apply(args, arguments);
+      return fn.apply(null, args);
+    };
+  }
+
+  /**
+   * A no-operation function.
+   *
+   * @private
+   */
+  function noop() {
+    // no operation performed
+  }
+
+  /**
+   * A wrapper around require() to suppress `module missing` errors.
+   *
+   * @private
+   * @param {String} id The module id.
+   * @returns {Mixed} The exported module or `null`.
+   */
+  function req(id) {
+    try {
+      var result = freeExports && freeRequire(id);
+    } catch(e) { }
+    return result || null;
+  }
+
+  /**
+   * Runs a snippet of JavaScript via script injection.
+   *
+   * @private
+   * @param {String} code The code to run.
+   */
+  function runScript(code) {
+    var anchor = freeDefine ? define.amd : Benchmark,
+        script = doc.createElement('script'),
+        sibling = doc.getElementsByTagName('script')[0],
+        parent = sibling.parentNode,
+        prop = uid + 'runScript',
+        prefix = '(' + (freeDefine ? 'define.amd.' : 'Benchmark.') + prop + '||function(){})();';
+
+    // Firefox 2.0.0.2 cannot use script injection as intended because it executes
+    // asynchronously, but that's OK because script injection is only used to avoid
+    // the previously commented JaegerMonkey bug.
+    try {
+      // remove the inserted script *before* running the code to avoid differences
+      // in the expected script element count/order of the document.
+      script.appendChild(doc.createTextNode(prefix + code));
+      anchor[prop] = function() { destroyElement(script); };
+    } catch(e) {
+      parent = parent.cloneNode(false);
+      sibling = null;
+      script.text = code;
+    }
+    parent.insertBefore(script, sibling);
+    delete anchor[prop];
+  }
+
+  /**
+   * A helper function for setting options/event handlers.
+   *
+   * @private
+   * @param {Object} bench The benchmark instance.
+   * @param {Object} [options={}] Options object.
+   */
+  function setOptions(bench, options) {
+    options = extend({}, bench.constructor.options, options);
+    bench.options = forOwn(options, function(value, key) {
+      if (value != null) {
+        // add event listeners
+        if (/^on[A-Z]/.test(key)) {
+          forEach(key.split(' '), function(key) {
+            bench.on(key.slice(2).toLowerCase(), value);
+          });
+        } else if (!hasKey(bench, key)) {
+          bench[key] = deepClone(value);
+        }
+      }
+    });
+  }
+
+  /*--------------------------------------------------------------------------*/
+
+  /**
+   * Handles cycling/completing the deferred benchmark.
+   *
+   * @memberOf Benchmark.Deferred
+   */
+  function resolve() {
+    var me = this,
+        clone = me.benchmark,
+        bench = clone._original;
+
+    if (bench.aborted) {
+      // cycle() -> clone cycle/complete event -> compute()'s invoked bench.run() cycle/complete
+      me.teardown();
+      clone.running = false;
+      cycle(me);
+    }
+    else if (++me.cycles < clone.count) {
+      // continue the test loop
+      if (support.timeout) {
+        // use setTimeout to avoid a call stack overflow if called recursively
+        setTimeout(function() { clone.compiled.call(me, timer); }, 0);
+      } else {
+        clone.compiled.call(me, timer);
+      }
+    }
+    else {
+      timer.stop(me);
+      me.teardown();
+      delay(clone, function() { cycle(me); });
+    }
+  }
+
+  /*--------------------------------------------------------------------------*/
+
+  /**
+   * A deep clone utility.
+   *
+   * @static
+   * @memberOf Benchmark
+   * @param {Mixed} value The value to clone.
+   * @returns {Mixed} The cloned value.
+   */
+  function deepClone(value) {
+    var accessor,
+        circular,
+        clone,
+        ctor,
+        descriptor,
+        extensible,
+        key,
+        length,
+        markerKey,
+        parent,
+        result,
+        source,
+        subIndex,
+        data = { 'value': value },
+        index = 0,
+        marked = [],
+        queue = { 'length': 0 },
+        unmarked = [];
+
+    /**
+     * An easily detectable decorator for cloned values.
+     */
+    function Marker(object) {
+      this.raw = object;
+    }
+
+    /**
+     * The callback used by `forProps()`.
+     */
+    function forPropsCallback(subValue, subKey) {
+      // exit early to avoid cloning the marker
+      if (subValue && subValue.constructor == Marker) {
+        return;
+      }
+      // add objects to the queue
+      if (subValue === Object(subValue)) {
+        queue[queue.length++] = { 'key': subKey, 'parent': clone, 'source': value };
+      }
+      // assign non-objects
+      else {
+        try {
+          // will throw an error in strict mode if the property is read-only
+          clone[subKey] = subValue;
+        } catch(e) { }
+      }
+    }
+
+    /**
+     * Gets an available marker key for the given object.
+     */
+    function getMarkerKey(object) {
+      // avoid collisions with existing keys
+      var result = uid;
+      while (object[result] && object[result].constructor != Marker) {
+        result += 1;
+      }
+      return result;
+    }
+
+    do {
+      key = data.key;
+      parent = data.parent;
+      source = data.source;
+      clone = value = source ? source[key] : data.value;
+      accessor = circular = descriptor = false;
+
+      // create a basic clone to filter out functions, DOM elements, and
+      // other non `Object` objects
+      if (value === Object(value)) {
+        // use custom deep clone function if available
+        if (isClassOf(value.deepClone, 'Function')) {
+          clone = value.deepClone();
+        } else {
+          ctor = value.constructor;
+          switch (toString.call(value)) {
+            case '[object Array]':
+              clone = new ctor(value.length);
+              break;
+
+            case '[object Boolean]':
+              clone = new ctor(value == true);
+              break;
+
+            case '[object Date]':
+              clone = new ctor(+value);
+              break;
+
+            case '[object Object]':
+              isPlainObject(value) && (clone = {});
+              break;
+
+            case '[object Number]':
+            case '[object String]':
+              clone = new ctor(value);
+              break;
+
+            case '[object RegExp]':
+              clone = ctor(value.source,
+                (value.global     ? 'g' : '') +
+                (value.ignoreCase ? 'i' : '') +
+                (value.multiline  ? 'm' : ''));
+          }
+        }
+        // continue clone if `value` doesn't have an accessor descriptor
+        // http://es5.github.com/#x8.10.1
+        if (clone && clone != value &&
+            !(descriptor = source && support.descriptors && getDescriptor(source, key),
+              accessor = descriptor && (descriptor.get || descriptor.set))) {
+          // use an existing clone (circular reference)
+          if ((extensible = isExtensible(value))) {
+            markerKey = getMarkerKey(value);
+            if (value[markerKey]) {
+              circular = clone = value[markerKey].raw;
+            }
+          } else {
+            // for frozen/sealed objects
+            for (subIndex = 0, length = unmarked.length; subIndex < length; subIndex++) {
+              data = unmarked[subIndex];
+              if (data.object === value) {
+                circular = clone = data.clone;
+                break;
+              }
+            }
+          }
+          if (!circular) {
+            // mark object to allow quickly detecting circular references and tie it to its clone
+            if (extensible) {
+              value[markerKey] = new Marker(clone);
+              marked.push({ 'key': markerKey, 'object': value });
+            } else {
+              // for frozen/sealed objects
+              unmarked.push({ 'clone': clone, 'object': value });
+            }
+            // iterate over object properties
+            forProps(value, forPropsCallback, { 'which': 'all' });
+          }
+        }
+      }
+      if (parent) {
+        // for custom property descriptors
+        if (accessor || (descriptor && !(descriptor.configurable && descriptor.enumerable && descriptor.writable))) {
+          if ('value' in descriptor) {
+            descriptor.value = clone;
+          }
+          setDescriptor(parent, key, descriptor);
+        }
+        // for default property descriptors
+        else {
+          parent[key] = clone;
+        }
+      } else {
+        result = clone;
+      }
+    } while ((data = queue[index++]));
+
+    // remove markers
+    for (index = 0, length = marked.length; index < length; index++) {
+      data = marked[index];
+      delete data.object[data.key];
+    }
+    return result;
+  }
+
+  /**
+   * An iteration utility for arrays and objects.
+   * Callbacks may terminate the loop by explicitly returning `false`.
+   *
+   * @static
+   * @memberOf Benchmark
+   * @param {Array|Object} object The object to iterate over.
+   * @param {Function} callback The function called per iteration.
+   * @param {Mixed} thisArg The `this` binding for the callback.
+   * @returns {Array|Object} Returns the object iterated over.
+   */
+  function each(object, callback, thisArg) {
+    var result = object;
+    object = Object(object);
+
+    var fn = callback,
+        index = -1,
+        length = object.length,
+        isSnapshot = !!(object.snapshotItem && (length = object.snapshotLength)),
+        isSplittable = (noCharByIndex || noCharByOwnIndex) && isClassOf(object, 'String'),
+        isConvertable = isSnapshot || isSplittable || 'item' in object,
+        origObject = object;
+
+    // in Opera < 10.5 `hasKey(object, 'length')` returns `false` for NodeLists
+    if (length === length >>> 0) {
+      if (isConvertable) {
+        // the third argument of the callback is the original non-array object
+        callback = function(value, index) {
+          return fn.call(this, value, index, origObject);
+        };
+        // in IE < 9 strings don't support accessing characters by index
+        if (isSplittable) {
+          object = object.split('');
+        } else {
+          object = [];
+          while (++index < length) {
+            // in Safari 2 `index in object` is always `false` for NodeLists
+            object[index] = isSnapshot ? result.snapshotItem(index) : result[index];
+          }
+        }
+      }
+      forEach(object, callback, thisArg);
+    } else {
+      forOwn(object, callback, thisArg);
+    }
+    return result;
+  }
+
+  /**
+   * Copies enumerable properties from the source(s) object to the destination object.
+   *
+   * @static
+   * @memberOf Benchmark
+   * @param {Object} destination The destination object.
+   * @param {Object} [source={}] The source object.
+   * @returns {Object} The destination object.
+   */
+  function extend(destination, source) {
+    // Chrome < 14 incorrectly sets `destination` to `undefined` when we `delete arguments[0]`
+    // http://code.google.com/p/v8/issues/detail?id=839
+    var result = destination;
+    delete arguments[0];
+
+    forEach(arguments, function(source) {
+      forProps(source, function(value, key) {
+        result[key] = value;
+      });
+    });
+    return result;
+  }
+
+  /**
+   * A generic `Array#filter` like method.
+   *
+   * @static
+   * @memberOf Benchmark
+   * @param {Array} array The array to iterate over.
+   * @param {Function|String} callback The function/alias called per iteration.
+   * @param {Mixed} thisArg The `this` binding for the callback.
+   * @returns {Array} A new array of values that passed callback filter.
+   * @example
+   *
+   * // get odd numbers
+   * Benchmark.filter([1, 2, 3, 4, 5], function(n) {
+   *   return n % 2;
+   * }); // -> [1, 3, 5];
+   *
+   * // get fastest benchmarks
+   * Benchmark.filter(benches, 'fastest');
+   *
+   * // get slowest benchmarks
+   * Benchmark.filter(benches, 'slowest');
+   *
+   * // get benchmarks that completed without erroring
+   * Benchmark.filter(benches, 'successful');
+   */
+  function filter(array, callback, thisArg) {
+    var result;
+
+    if (callback == 'successful') {
+      // callback to exclude those that are errored, unrun, or have hz of Infinity
+      callback = function(bench) { return bench.cycles && isFinite(bench.hz); };
+    }
+    else if (callback == 'fastest' || callback == 'slowest') {
+      // get successful, sort by period + margin of error, and filter fastest/slowest
+      result = filter(array, 'successful').sort(function(a, b) {
+        a = a.stats; b = b.stats;
+        return (a.mean + a.moe > b.mean + b.moe ? 1 : -1) * (callback == 'fastest' ? 1 : -1);
+      });
+      result = filter(result, function(bench) {
+        return result[0].compare(bench) == 0;
+      });
+    }
+    return result || reduce(array, function(result, value, index) {
+      return callback.call(thisArg, value, index, array) ? (result.push(value), result) : result;
+    }, []);
+  }
+
+  /**
+   * A generic `Array#forEach` like method.
+   * Callbacks may terminate the loop by explicitly returning `false`.
+   *
+   * @static
+   * @memberOf Benchmark
+   * @param {Array} array The array to iterate over.
+   * @param {Function} callback The function called per iteration.
+   * @param {Mixed} thisArg The `this` binding for the callback.
+   * @returns {Array} Returns the array iterated over.
+   */
+  function forEach(array, callback, thisArg) {
+    var index = -1,
+        length = (array = Object(array)).length >>> 0;
+
+    if (thisArg !== undefined) {
+      callback = bind(callback, thisArg);
+    }
+    while (++index < length) {
+      if (index in array &&
+          callback(array[index], index, array) === false) {
+        break;
+      }
+    }
+    return array;
+  }
+
+  /**
+   * Iterates over an object's own properties, executing the `callback` for each.
+   * Callbacks may terminate the loop by explicitly returning `false`.
+   *
+   * @static
+   * @memberOf Benchmark
+   * @param {Object} object The object to iterate over.
+   * @param {Function} callback The function executed per own property.
+   * @param {Mixed} thisArg The `this` binding for the callback.
+   * @returns {Object} Returns the object iterated over.
+   */
+  function forOwn(object, callback, thisArg) {
+    return forProps(object, callback, { 'bind': thisArg, 'which': 'own' });
+  }
+
+  /**
+   * Converts a number to a more readable comma-separated string representation.
+   *
+   * @static
+   * @memberOf Benchmark
+   * @param {Number} number The number to convert.
+   * @returns {String} The more readable string representation.
+   */
+  function formatNumber(number) {
+    number = String(number).split('.');
+    return number[0].replace(/(?=(?:\d{3})+$)(?!\b)/g, ',') +
+      (number[1] ? '.' + number[1] : '');
+  }
+
+  /**
+   * Checks if an object has the specified key as a direct property.
+   *
+   * @static
+   * @memberOf Benchmark
+   * @param {Object} object The object to check.
+   * @param {String} key The key to check for.
+   * @returns {Boolean} Returns `true` if key is a direct property, else `false`.
+   */
+  function hasKey() {
+    // lazy define for worst case fallback (not as accurate)
+    hasKey = function(object, key) {
+      var parent = object != null && (object.constructor || Object).prototype;
+      return !!parent && key in Object(object) && !(key in parent && object[key] === parent[key]);
+    };
+    // for modern browsers
+    if (isClassOf(hasOwnProperty, 'Function')) {
+      hasKey = function(object, key) {
+        return object != null && hasOwnProperty.call(object, key);
+      };
+    }
+    // for Safari 2
+    else if ({}.__proto__ == Object.prototype) {
+      hasKey = function(object, key) {
+        var result = false;
+        if (object != null) {
+          object = Object(object);
+          object.__proto__ = [object.__proto__, object.__proto__ = null, result = key in object][0];
+        }
+        return result;
+      };
+    }
+    return hasKey.apply(this, arguments);
+  }
+
+  /**
+   * A generic `Array#indexOf` like method.
+   *
+   * @static
+   * @memberOf Benchmark
+   * @param {Array} array The array to iterate over.
+   * @param {Mixed} value The value to search for.
+   * @param {Number} [fromIndex=0] The index to start searching from.
+   * @returns {Number} The index of the matched value or `-1`.
+   */
+  function indexOf(array, value, fromIndex) {
+    var index = toInteger(fromIndex),
+        length = (array = Object(array)).length >>> 0;
+
+    index = (index < 0 ? max(0, length + index) : index) - 1;
+    while (++index < length) {
+      if (index in array && value === array[index]) {
+        return index;
+      }
+    }
+    return -1;
+  }
+
+  /**
+   * Modify a string by replacing named tokens with matching object property values.
+   *
+   * @static
+   * @memberOf Benchmark
+   * @param {String} string The string to modify.
+   * @param {Object} object The template object.
+   * @returns {String} The modified string.
+   */
+  function interpolate(string, object) {
+    forOwn(object, function(value, key) {
+      // escape regexp special characters in `key`
+      string = string.replace(RegExp('#\\{' + key.replace(/([.*+?^=!:${}()|[\]\/\\])/g, '\\$1') + '\\}', 'g'), value);
+    });
+    return string;
+  }
+
+  /**
+   * Invokes a method on all items in an array.
+   *
+   * @static
+   * @memberOf Benchmark
+   * @param {Array} benches Array of benchmarks to iterate over.
+   * @param {String|Object} name The name of the method to invoke OR options object.
+   * @param {Mixed} [arg1, arg2, ...] Arguments to invoke the method with.
+   * @returns {Array} A new array of values returned from each method invoked.
+   * @example
+   *
+   * // invoke `reset` on all benchmarks
+   * Benchmark.invoke(benches, 'reset');
+   *
+   * // invoke `emit` with arguments
+   * Benchmark.invoke(benches, 'emit', 'complete', listener);
+   *
+   * // invoke `run(true)`, treat benchmarks as a queue, and register invoke callbacks
+   * Benchmark.invoke(benches, {
+   *
+   *   // invoke the `run` method
+   *   'name': 'run',
+   *
+   *   // pass a single argument
+   *   'args': true,
+   *
+   *   // treat as queue, removing benchmarks from front of `benches` until empty
+   *   'queued': true,
+   *
+   *   // called before any benchmarks have been invoked.
+   *   'onStart': onStart,
+   *
+   *   // called between invoking benchmarks
+   *   'onCycle': onCycle,
+   *
+   *   // called after all benchmarks have been invoked.
+   *   'onComplete': onComplete
+   * });
+   */
+  function invoke(benches, name) {
+    var args,
+        bench,
+        queued,
+        index = -1,
+        eventProps = { 'currentTarget': benches },
+        options = { 'onStart': noop, 'onCycle': noop, 'onComplete': noop },
+        result = map(benches, function(bench) { return bench; });
+
+    /**
+     * Invokes the method of the current object and if synchronous, fetches the next.
+     */
+    function execute() {
+      var listeners,
+          async = isAsync(bench);
+
+      if (async) {
+        // use `getNext` as the first listener
+        bench.on('complete', getNext);
+        listeners = bench.events.complete;
+        listeners.splice(0, 0, listeners.pop());
+      }
+      // execute method
+      result[index] = isClassOf(bench && bench[name], 'Function') ? bench[name].apply(bench, args) : undefined;
+      // if synchronous return true until finished
+      return !async && getNext();
+    }
+
+    /**
+     * Fetches the next bench or executes `onComplete` callback.
+     */
+    function getNext(event) {
+      var cycleEvent,
+          last = bench,
+          async = isAsync(last);
+
+      if (async) {
+        last.off('complete', getNext);
+        last.emit('complete');
+      }
+      // emit "cycle" event
+      eventProps.type = 'cycle';
+      eventProps.target = last;
+      cycleEvent = Event(eventProps);
+      options.onCycle.call(benches, cycleEvent);
+
+      // choose next benchmark if not exiting early
+      if (!cycleEvent.aborted && raiseIndex() !== false) {
+        bench = queued ? benches[0] : result[index];
+        if (isAsync(bench)) {
+          delay(bench, execute);
+        }
+        else if (async) {
+          // resume execution if previously asynchronous but now synchronous
+          while (execute()) { }
+        }
+        else {
+          // continue synchronous execution
+          return true;
+        }
+      } else {
+        // emit "complete" event
+        eventProps.type = 'complete';
+        options.onComplete.call(benches, Event(eventProps));
+      }
+      // When used as a listener `event.aborted = true` will cancel the rest of
+      // the "complete" listeners because they were already called above and when
+      // used as part of `getNext` the `return false` will exit the execution while-loop.
+      if (event) {
+        event.aborted = true;
+      } else {
+        return false;
+      }
+    }
+
+    /**
+     * Checks if invoking `Benchmark#run` with asynchronous cycles.
+     */
+    function isAsync(object) {
+      // avoid using `instanceof` here because of IE memory leak issues with host objects
+      var async = args[0] && args[0].async;
+      return Object(object).constructor == Benchmark && name == 'run' &&
+        ((async == null ? object.options.async : async) && support.timeout || object.defer);
+    }
+
+    /**
+     * Raises `index` to the next defined index or returns `false`.
+     */
+    function raiseIndex() {
+      var length = result.length;
+      if (queued) {
+        // if queued remove the previous bench and subsequent skipped non-entries
+        do {
+          ++index > 0 && shift.call(benches);
+        } while ((length = benches.length) && !('0' in benches));
+      }
+      else {
+        while (++index < length && !(index in result)) { }
+      }
+      // if we reached the last index then return `false`
+      return (queued ? length : index < length) ? index : (index = false);
+    }
+
+    // juggle arguments
+    if (isClassOf(name, 'String')) {
+      // 2 arguments (array, name)
+      args = slice.call(arguments, 2);
+    } else {
+      // 2 arguments (array, options)
+      options = extend(options, name);
+      name = options.name;
+      args = isClassOf(args = 'args' in options ? options.args : [], 'Array') ? args : [args];
+      queued = options.queued;
+    }
+
+    // start iterating over the array
+    if (raiseIndex() !== false) {
+      // emit "start" event
+      bench = result[index];
+      eventProps.type = 'start';
+      eventProps.target = bench;
+      options.onStart.call(benches, Event(eventProps));
+
+      // end early if the suite was aborted in an "onStart" listener
+      if (benches.aborted && benches.constructor == Suite && name == 'run') {
+        // emit "cycle" event
+        eventProps.type = 'cycle';
+        options.onCycle.call(benches, Event(eventProps));
+        // emit "complete" event
+        eventProps.type = 'complete';
+        options.onComplete.call(benches, Event(eventProps));
+      }
+      // else start
+      else {
+        if (isAsync(bench)) {
+          delay(bench, execute);
+        } else {
+          while (execute()) { }
+        }
+      }
+    }
+    return result;
+  }
+
+  /**
+   * Creates a string of joined array values or object key-value pairs.
+   *
+   * @static
+   * @memberOf Benchmark
+   * @param {Array|Object} object The object to operate on.
+   * @param {String} [separator1=','] The separator used between key-value pairs.
+   * @param {String} [separator2=': '] The separator used between keys and values.
+   * @returns {String} The joined result.
+   */
+  function join(object, separator1, separator2) {
+    var result = [],
+        length = (object = Object(object)).length,
+        arrayLike = length === length >>> 0;
+
+    separator2 || (separator2 = ': ');
+    each(object, function(value, key) {
+      result.push(arrayLike ? value : key + separator2 + value);
+    });
+    return result.join(separator1 || ',');
+  }
+
+  /**
+   * A generic `Array#map` like method.
+   *
+   * @static
+   * @memberOf Benchmark
+   * @param {Array} array The array to iterate over.
+   * @param {Function} callback The function called per iteration.
+   * @param {Mixed} thisArg The `this` binding for the callback.
+   * @returns {Array} A new array of values returned by the callback.
+   */
+  function map(array, callback, thisArg) {
+    return reduce(array, function(result, value, index) {
+      result[index] = callback.call(thisArg, value, index, array);
+      return result;
+    }, Array(Object(array).length >>> 0));
+  }
+
+  /**
+   * Retrieves the value of a specified property from all items in an array.
+   *
+   * @static
+   * @memberOf Benchmark
+   * @param {Array} array The array to iterate over.
+   * @param {String} property The property to pluck.
+   * @returns {Array} A new array of property values.
+   */
+  function pluck(array, property) {
+    return map(array, function(object) {
+      return object == null ? undefined : object[property];
+    });
+  }
+
+  /**
+   * A generic `Array#reduce` like method.
+   *
+   * @static
+   * @memberOf Benchmark
+   * @param {Array} array The array to iterate over.
+   * @param {Function} callback The function called per iteration.
+   * @param {Mixed} accumulator Initial value of the accumulator.
+   * @returns {Mixed} The accumulator.
+   */
+  function reduce(array, callback, accumulator) {
+    var noaccum = arguments.length < 3;
+    forEach(array, function(value, index) {
+      accumulator = noaccum ? (noaccum = false, value) : callback(accumulator, value, index, array);
+    });
+    return accumulator;
+  }
+
+  /*--------------------------------------------------------------------------*/
+
+  /**
+   * Aborts all benchmarks in the suite.
+   *
+   * @name abort
+   * @memberOf Benchmark.Suite
+   * @returns {Object} The suite instance.
+   */
+  function abortSuite() {
+    var event,
+        me = this,
+        resetting = calledBy.resetSuite;
+
+    if (me.running) {
+      event = Event('abort');
+      me.emit(event);
+      if (!event.cancelled || resetting) {
+        // avoid infinite recursion
+        calledBy.abortSuite = true;
+        me.reset();
+        delete calledBy.abortSuite;
+
+        if (!resetting) {
+          me.aborted = true;
+          invoke(me, 'abort');
+        }
+      }
+    }
+    return me;
+  }
+
+  /**
+   * Adds a test to the benchmark suite.
+   *
+   * @memberOf Benchmark.Suite
+   * @param {String} name A name to identify the benchmark.
+   * @param {Function|String} fn The test to benchmark.
+   * @param {Object} [options={}] Options object.
+   * @returns {Object} The benchmark instance.
+   * @example
+   *
+   * // basic usage
+   * suite.add(fn);
+   *
+   * // or using a name first
+   * suite.add('foo', fn);
+   *
+   * // or with options
+   * suite.add('foo', fn, {
+   *   'onCycle': onCycle,
+   *   'onComplete': onComplete
+   * });
+   *
+   * // or name and options
+   * suite.add('foo', {
+   *   'fn': fn,
+   *   'onCycle': onCycle,
+   *   'onComplete': onComplete
+   * });
+   *
+   * // or options only
+   * suite.add({
+   *   'name': 'foo',
+   *   'fn': fn,
+   *   'onCycle': onCycle,
+   *   'onComplete': onComplete
+   * });
+   */
+  function add(name, fn, options) {
+    var me = this,
+        bench = Benchmark(name, fn, options),
+        event = Event({ 'type': 'add', 'target': bench });
+
+    if (me.emit(event), !event.cancelled) {
+      me.push(bench);
+    }
+    return me;
+  }
+
+  /**
+   * Creates a new suite with cloned benchmarks.
+   *
+   * @name clone
+   * @memberOf Benchmark.Suite
+   * @param {Object} options Options object to overwrite cloned options.
+   * @returns {Object} The new suite instance.
+   */
+  function cloneSuite(options) {
+    var me = this,
+        result = new me.constructor(extend({}, me.options, options));
+
+    // copy own properties
+    forOwn(me, function(value, key) {
+      if (!hasKey(result, key)) {
+        result[key] = value && isClassOf(value.clone, 'Function')
+          ? value.clone()
+          : deepClone(value);
+      }
+    });
+    return result;
+  }
+
+  /**
+   * An `Array#filter` like method.
+   *
+   * @name filter
+   * @memberOf Benchmark.Suite
+   * @param {Function|String} callback The function/alias called per iteration.
+   * @returns {Object} A new suite of benchmarks that passed callback filter.
+   */
+  function filterSuite(callback) {
+    var me = this,
+        result = new me.constructor;
+
+    result.push.apply(result, filter(me, callback));
+    return result;
+  }
+
+  /**
+   * Resets all benchmarks in the suite.
+   *
+   * @name reset
+   * @memberOf Benchmark.Suite
+   * @returns {Object} The suite instance.
+   */
+  function resetSuite() {
+    var event,
+        me = this,
+        aborting = calledBy.abortSuite;
+
+    if (me.running && !aborting) {
+      // no worries, `resetSuite()` is called within `abortSuite()`
+      calledBy.resetSuite = true;
+      me.abort();
+      delete calledBy.resetSuite;
+    }
+    // reset if the state has changed
+    else if ((me.aborted || me.running) &&
+        (me.emit(event = Event('reset')), !event.cancelled)) {
+      me.running = false;
+      if (!aborting) {
+        invoke(me, 'reset');
+      }
+    }
+    return me;
+  }
+
+  /**
+   * Runs the suite.
+   *
+   * @name run
+   * @memberOf Benchmark.Suite
+   * @param {Object} [options={}] Options object.
+   * @returns {Object} The suite instance.
+   * @example
+   *
+   * // basic usage
+   * suite.run();
+   *
+   * // or with options
+   * suite.run({ 'async': true, 'queued': true });
+   */
+  function runSuite(options) {
+    var me = this;
+
+    me.reset();
+    me.running = true;
+    options || (options = {});
+
+    invoke(me, {
+      'name': 'run',
+      'args': options,
+      'queued': options.queued,
+      'onStart': function(event) {
+        me.emit(event);
+      },
+      'onCycle': function(event) {
+        var bench = event.target;
+        if (bench.error) {
+          me.emit({ 'type': 'error', 'target': bench });
+        }
+        me.emit(event);
+        event.aborted = me.aborted;
+      },
+      'onComplete': function(event) {
+        me.running = false;
+        me.emit(event);
+      }
+    });
+    return me;
+  }
+
+  /*--------------------------------------------------------------------------*/
+
+  /**
+   * Executes all registered listeners of the specified event type.
+   *
+   * @memberOf Benchmark, Benchmark.Suite
+   * @param {String|Object} type The event type or object.
+   * @returns {Mixed} Returns the return value of the last listener executed.
+   */
+  function emit(type) {
+    var listeners,
+        me = this,
+        event = Event(type),
+        events = me.events,
+        args = (arguments[0] = event, arguments);
+
+    event.currentTarget || (event.currentTarget = me);
+    event.target || (event.target = me);
+    delete event.result;
+
+    if (events && (listeners = hasKey(events, event.type) && events[event.type])) {
+      forEach(listeners.slice(), function(listener) {
+        if ((event.result = listener.apply(me, args)) === false) {
+          event.cancelled = true;
+        }
+        return !event.aborted;
+      });
+    }
+    return event.result;
+  }
+
+  /**
+   * Returns an array of event listeners for a given type that can be manipulated
+   * to add or remove listeners.
+   *
+   * @memberOf Benchmark, Benchmark.Suite
+   * @param {String} type The event type.
+   * @returns {Array} The listeners array.
+   */
+  function listeners(type) {
+    var me = this,
+        events = me.events || (me.events = {});
+
+    return hasKey(events, type) ? events[type] : (events[type] = []);
+  }
+
+  /**
+   * Unregisters a listener for the specified event type(s),
+   * or unregisters all listeners for the specified event type(s),
+   * or unregisters all listeners for all event types.
+   *
+   * @memberOf Benchmark, Benchmark.Suite
+   * @param {String} [type] The event type.
+   * @param {Function} [listener] The function to unregister.
+   * @returns {Object} The benchmark instance.
+   * @example
+   *
+   * // unregister a listener for an event type
+   * bench.off('cycle', listener);
+   *
+   * // unregister a listener for multiple event types
+   * bench.off('start cycle', listener);
+   *
+   * // unregister all listeners for an event type
+   * bench.off('cycle');
+   *
+   * // unregister all listeners for multiple event types
+   * bench.off('start cycle complete');
+   *
+   * // unregister all listeners for all event types
+   * bench.off();
+   */
+  function off(type, listener) {
+    var me = this,
+        events = me.events;
+
+    events && each(type ? type.split(' ') : events, function(listeners, type) {
+      var index;
+      if (typeof listeners == 'string') {
+        type = listeners;
+        listeners = hasKey(events, type) && events[type];
+      }
+      if (listeners) {
+        if (listener) {
+          index = indexOf(listeners, listener);
+          if (index > -1) {
+            listeners.splice(index, 1);
+          }
+        } else {
+          listeners.length = 0;
+        }
+      }
+    });
+    return me;
+  }
+
+  /**
+   * Registers a listener for the specified event type(s).
+   *
+   * @memberOf Benchmark, Benchmark.Suite
+   * @param {String} type The event type.
+   * @param {Function} listener The function to register.
+   * @returns {Object} The benchmark instance.
+   * @example
+   *
+   * // register a listener for an event type
+   * bench.on('cycle', listener);
+   *
+   * // register a listener for multiple event types
+   * bench.on('start cycle', listener);
+   */
+  function on(type, listener) {
+    var me = this,
+        events = me.events || (me.events = {});
+
+    forEach(type.split(' '), function(type) {
+      (hasKey(events, type)
+        ? events[type]
+        : (events[type] = [])
+      ).push(listener);
+    });
+    return me;
+  }
+
+  /*--------------------------------------------------------------------------*/
+
+  /**
+   * Aborts the benchmark without recording times.
+   *
+   * @memberOf Benchmark
+   * @returns {Object} The benchmark instance.
+   */
+  function abort() {
+    var event,
+        me = this,
+        resetting = calledBy.reset;
+
+    if (me.running) {
+      event = Event('abort');
+      me.emit(event);
+      if (!event.cancelled || resetting) {
+        // avoid infinite recursion
+        calledBy.abort = true;
+        me.reset();
+        delete calledBy.abort;
+
+        if (support.timeout) {
+          clearTimeout(me._timerId);
+          delete me._timerId;
+        }
+        if (!resetting) {
+          me.aborted = true;
+          me.running = false;
+        }
+      }
+    }
+    return me;
+  }
+
+  /**
+   * Creates a new benchmark using the same test and options.
+   *
+   * @memberOf Benchmark
+   * @param {Object} options Options object to overwrite cloned options.
+   * @returns {Object} The new benchmark instance.
+   * @example
+   *
+   * var bizarro = bench.clone({
+   *   'name': 'doppelganger'
+   * });
+   */
+  function clone(options) {
+    var me = this,
+        result = new me.constructor(extend({}, me, options));
+
+    // correct the `options` object
+    result.options = extend({}, me.options, options);
+
+    // copy own custom properties
+    forOwn(me, function(value, key) {
+      if (!hasKey(result, key)) {
+        result[key] = deepClone(value);
+      }
+    });
+    return result;
+  }
+
+  /**
+   * Determines if a benchmark is faster than another.
+   *
+   * @memberOf Benchmark
+   * @param {Object} other The benchmark to compare.
+   * @returns {Number} Returns `-1` if slower, `1` if faster, and `0` if indeterminate.
+   */
+  function compare(other) {
+    var critical,
+        zStat,
+        me = this,
+        sample1 = me.stats.sample,
+        sample2 = other.stats.sample,
+        size1 = sample1.length,
+        size2 = sample2.length,
+        maxSize = max(size1, size2),
+        minSize = min(size1, size2),
+        u1 = getU(sample1, sample2),
+        u2 = getU(sample2, sample1),
+        u = min(u1, u2);
+
+    function getScore(xA, sampleB) {
+      return reduce(sampleB, function(total, xB) {
+        return total + (xB > xA ? 0 : xB < xA ? 1 : 0.5);
+      }, 0);
+    }
+
+    function getU(sampleA, sampleB) {
+      return reduce(sampleA, function(total, xA) {
+        return total + getScore(xA, sampleB);
+      }, 0);
+    }
+
+    function getZ(u) {
+      return (u - ((size1 * size2) / 2)) / sqrt((size1 * size2 * (size1 + size2 + 1)) / 12);
+    }
+
+    // exit early if comparing the same benchmark
+    if (me == other) {
+      return 0;
+    }
+    // reject the null hyphothesis the two samples come from the
+    // same population (i.e. have the same median) if...
+    if (size1 + size2 > 30) {
+      // ...the z-stat is greater than 1.96 or less than -1.96
+      // http://www.statisticslectures.com/topics/mannwhitneyu/
+      zStat = getZ(u);
+      return abs(zStat) > 1.96 ? (zStat > 0 ? -1 : 1) : 0;
+    }
+    // ...the U value is less than or equal the critical U value
+    // http://www.geoib.com/mann-whitney-u-test.html
+    critical = maxSize < 5 || minSize < 3 ? 0 : uTable[maxSize][minSize - 3];
+    return u <= critical ? (u == u1 ? 1 : -1) : 0;
+  }
+
+  /**
+   * Reset properties and abort if running.
+   *
+   * @memberOf Benchmark
+   * @returns {Object} The benchmark instance.
+   */
+  function reset() {
+    var data,
+        event,
+        me = this,
+        index = 0,
+        changes = { 'length': 0 },
+        queue = { 'length': 0 };
+
+    if (me.running && !calledBy.abort) {
+      // no worries, `reset()` is called within `abort()`
+      calledBy.reset = true;
+      me.abort();
+      delete calledBy.reset;
+    }
+    else {
+      // a non-recursive solution to check if properties have changed
+      // http://www.jslab.dk/articles/non.recursive.preorder.traversal.part4
+      data = { 'destination': me, 'source': extend({}, me.constructor.prototype, me.options) };
+      do {
+        forOwn(data.source, function(value, key) {
+          var changed,
+              destination = data.destination,
+              currValue = destination[key];
+
+          if (value && typeof value == 'object') {
+            if (isClassOf(value, 'Array')) {
+              // check if an array value has changed to a non-array value
+              if (!isClassOf(currValue, 'Array')) {
+                changed = currValue = [];
+              }
+              // or has changed its length
+              if (currValue.length != value.length) {
+                changed = currValue = currValue.slice(0, value.length);
+                currValue.length = value.length;
+              }
+            }
+            // check if an object has changed to a non-object value
+            else if (!currValue || typeof currValue != 'object') {
+              changed = currValue = {};
+            }
+            // register a changed object
+            if (changed) {
+              changes[changes.length++] = { 'destination': destination, 'key': key, 'value': currValue };
+            }
+            queue[queue.length++] = { 'destination': currValue, 'source': value };
+          }
+          // register a changed primitive
+          else if (value !== currValue && !(value == null || isClassOf(value, 'Function'))) {
+            changes[changes.length++] = { 'destination': destination, 'key': key, 'value': value };
+          }
+        });
+      }
+      while ((data = queue[index++]));
+
+      // if changed emit the `reset` event and if it isn't cancelled reset the benchmark
+      if (changes.length && (me.emit(event = Event('reset')), !event.cancelled)) {
+        forEach(changes, function(data) {
+          data.destination[data.key] = data.value;
+        });
+      }
+    }
+    return me;
+  }
+
+  /**
+   * Displays relevant benchmark information when coerced to a string.
+   *
+   * @name toString
+   * @memberOf Benchmark
+   * @returns {String} A string representation of the benchmark instance.
+   */
+  function toStringBench() {
+    var me = this,
+        error = me.error,
+        hz = me.hz,
+        id = me.id,
+        stats = me.stats,
+        size = stats.sample.length,
+        pm = support.java ? '+/-' : '\xb1',
+        result = me.name || (isNaN(id) ? id : '<Test #' + id + '>');
+
+    if (error) {
+      result += ': ' + join(error);
+    } else {
+      result += ' x ' + formatNumber(hz.toFixed(hz < 100 ? 2 : 0)) + ' ops/sec ' + pm +
+        stats.rme.toFixed(2) + '% (' + size + ' run' + (size == 1 ? '' : 's') + ' sampled)';
+    }
+    return result;
+  }
+
+  /*--------------------------------------------------------------------------*/
+
+  /**
+   * Clocks the time taken to execute a test per cycle (secs).
+   *
+   * @private
+   * @param {Object} bench The benchmark instance.
+   * @returns {Number} The time taken.
+   */
+  function clock() {
+    var applet,
+        options = Benchmark.options,
+        template = { 'begin': 's$=new n$', 'end': 'r$=(new n$-s$)/1e3', 'uid': uid },
+        timers = [{ 'ns': timer.ns, 'res': max(0.0015, getRes('ms')), 'unit': 'ms' }];
+
+    // lazy define for hi-res timers
+    clock = function(clone) {
+      var deferred;
+      if (clone instanceof Deferred) {
+        deferred = clone;
+        clone = deferred.benchmark;
+      }
+
+      var bench = clone._original,
+          fn = bench.fn,
+          fnArg = deferred ? getFirstArgument(fn) || 'deferred' : '',
+          stringable = isStringable(fn);
+
+      var source = {
+        'setup': getSource(bench.setup, preprocess('m$.setup()')),
+        'fn': getSource(fn, preprocess('m$.fn(' + fnArg + ')')),
+        'fnArg': fnArg,
+        'teardown': getSource(bench.teardown, preprocess('m$.teardown()'))
+      };
+
+      var count = bench.count = clone.count,
+          decompilable = support.decompilation || stringable,
+          id = bench.id,
+          isEmpty = !(source.fn || stringable),
+          name = bench.name || (typeof id == 'number' ? '<Test #' + id + '>' : id),
+          ns = timer.ns,
+          result = 0;
+
+      // init `minTime` if needed
+      clone.minTime = bench.minTime || (bench.minTime = bench.options.minTime = options.minTime);
+
+      // repair nanosecond timer
+      // (some Chrome builds erase the `ns` variable after millions of executions)
+      if (applet) {
+        try {
+          ns.nanoTime();
+        } catch(e) {
+          // use non-element to avoid issues with libs that augment them
+          ns = timer.ns = new applet.Packages.nano;
+        }
+      }
+
+      // Compile in setup/teardown functions and the test loop.
+      // Create a new compiled test, instead of using the cached `bench.compiled`,
+      // to avoid potential engine optimizations enabled over the life of the test.
+      var compiled = bench.compiled = createFunction(preprocess('t$'), interpolate(
+        preprocess(deferred
+          ? 'var d$=this,#{fnArg}=d$,m$=d$.benchmark._original,f$=m$.fn,su$=m$.setup,td$=m$.teardown;' +
+            // when `deferred.cycles` is `0` then...
+            'if(!d$.cycles){' +
+            // set `deferred.fn`
+            'd$.fn=function(){var #{fnArg}=d$;if(typeof f$=="function"){try{#{fn}\n}catch(e$){f$(d$)}}else{#{fn}\n}};' +
+            // set `deferred.teardown`
+            'd$.teardown=function(){d$.cycles=0;if(typeof td$=="function"){try{#{teardown}\n}catch(e$){td$()}}else{#{teardown}\n}};' +
+            // execute the benchmark's `setup`
+            'if(typeof su$=="function"){try{#{setup}\n}catch(e$){su$()}}else{#{setup}\n};' +
+            // start timer
+            't$.start(d$);' +
+            // execute `deferred.fn` and return a dummy object
+            '}d$.fn();return{}'
+
+          : 'var r$,s$,m$=this,f$=m$.fn,i$=m$.count,n$=t$.ns;#{setup}\n#{begin};' +
+            'while(i$--){#{fn}\n}#{end};#{teardown}\nreturn{elapsed:r$,uid:"#{uid}"}'),
+        source
+      ));
+
+      try {
+        if (isEmpty) {
+          // Firefox may remove dead code from Function#toString results
+          // http://bugzil.la/536085
+          throw new Error('The test "' + name + '" is empty. This may be the result of dead code removal.');
+        }
+        else if (!deferred) {
+          // pretest to determine if compiled code is exits early, usually by a
+          // rogue `return` statement, by checking for a return object with the uid
+          bench.count = 1;
+          compiled = (compiled.call(bench, timer) || {}).uid == uid && compiled;
+          bench.count = count;
+        }
+      } catch(e) {
+        compiled = null;
+        clone.error = e || new Error(String(e));
+        bench.count = count;
+      }
+      // fallback when a test exits early or errors during pretest
+      if (decompilable && !compiled && !deferred && !isEmpty) {
+        compiled = createFunction(preprocess('t$'), interpolate(
+          preprocess(
+            (clone.error && !stringable
+              ? 'var r$,s$,m$=this,f$=m$.fn,i$=m$.count'
+              : 'function f$(){#{fn}\n}var r$,s$,m$=this,i$=m$.count'
+            ) +
+            ',n$=t$.ns;#{setup}\n#{begin};m$.f$=f$;while(i$--){m$.f$()}#{end};' +
+            'delete m$.f$;#{teardown}\nreturn{elapsed:r$}'
+          ),
+          source
+        ));
+
+        try {
+          // pretest one more time to check for errors
+          bench.count = 1;
+          compiled.call(bench, timer);
+          bench.compiled = compiled;
+          bench.count = count;
+          delete clone.error;
+        }
+        catch(e) {
+          bench.count = count;
+          if (clone.error) {
+            compiled = null;
+          } else {
+            bench.compiled = compiled;
+            clone.error = e || new Error(String(e));
+          }
+        }
+      }
+      // assign `compiled` to `clone` before calling in case a deferred benchmark
+      // immediately calls `deferred.resolve()`
+      clone.compiled = compiled;
+      // if no errors run the full test loop
+      if (!clone.error) {
+        result = compiled.call(deferred || bench, timer).elapsed;
+      }
+      return result;
+    };
+
+    /*------------------------------------------------------------------------*/
+
+    /**
+     * Gets the current timer's minimum resolution (secs).
+     */
+    function getRes(unit) {
+      var measured,
+          begin,
+          count = 30,
+          divisor = 1e3,
+          ns = timer.ns,
+          sample = [];
+
+      // get average smallest measurable time
+      while (count--) {
+        if (unit == 'us') {
+          divisor = 1e6;
+          if (ns.stop) {
+            ns.start();
+            while (!(measured = ns.microseconds())) { }
+          } else if (ns[perfName]) {
+            divisor = 1e3;
+            measured = Function('n', 'var r,s=n.' + perfName + '();while(!(r=n.' + perfName + '()-s)){};return r')(ns);
+          } else {
+            begin = ns();
+            while (!(measured = ns() - begin)) { }
+          }
+        }
+        else if (unit == 'ns') {
+          divisor = 1e9;
+          if (ns.nanoTime) {
+            begin = ns.nanoTime();
+            while (!(measured = ns.nanoTime() - begin)) { }
+          } else {
+            begin = (begin = ns())[0] + (begin[1] / divisor);
+            while (!(measured = ((measured = ns())[0] + (measured[1] / divisor)) - begin)) { }
+            divisor = 1;
+          }
+        }
+        else {
+          begin = new ns;
+          while (!(measured = new ns - begin)) { }
+        }
+        // check for broken timers (nanoTime may have issues)
+        // http://alivebutsleepy.srnet.cz/unreliable-system-nanotime/
+        if (measured > 0) {
+          sample.push(measured);
+        } else {
+          sample.push(Infinity);
+          break;
+        }
+      }
+      // convert to seconds
+      return getMean(sample) / divisor;
+    }
+
+    /**
+     * Replaces all occurrences of `$` with a unique number and
+     * template tokens with content.
+     */
+    function preprocess(code) {
+      return interpolate(code, template).replace(/\$/g, /\d+/.exec(uid));
+    }
+
+    /*------------------------------------------------------------------------*/
+
+    // detect nanosecond support from a Java applet
+    each(doc && doc.applets || [], function(element) {
+      return !(timer.ns = applet = 'nanoTime' in element && element);
+    });
+
+    // check type in case Safari returns an object instead of a number
+    try {
+      if (typeof timer.ns.nanoTime() == 'number') {
+        timers.push({ 'ns': timer.ns, 'res': getRes('ns'), 'unit': 'ns' });
+      }
+    } catch(e) { }
+
+    // detect Chrome's microsecond timer:
+    // enable benchmarking via the --enable-benchmarking command
+    // line switch in at least Chrome 7 to use chrome.Interval
+    try {
+      if ((timer.ns = new (window.chrome || window.chromium).Interval)) {
+        timers.push({ 'ns': timer.ns, 'res': getRes('us'), 'unit': 'us' });
+      }
+    } catch(e) { }
+
+    // detect `performance.now` microsecond resolution timer
+    if ((timer.ns = perfName && perfObject)) {
+      timers.push({ 'ns': timer.ns, 'res': getRes('us'), 'unit': 'us' });
+    }
+
+    // detect Node's nanosecond resolution timer available in Node >= 0.8
+    if (processObject && typeof (timer.ns = processObject.hrtime) == 'function') {
+      timers.push({ 'ns': timer.ns, 'res': getRes('ns'), 'unit': 'ns' });
+    }
+
+    // detect Wade Simmons' Node microtime module
+    if (microtimeObject && typeof (timer.ns = microtimeObject.now) == 'function') {
+      timers.push({ 'ns': timer.ns,  'res': getRes('us'), 'unit': 'us' });
+    }
+
+    // pick timer with highest resolution
+    timer = reduce(timers, function(timer, other) {
+      return other.res < timer.res ? other : timer;
+    });
+
+    // remove unused applet
+    if (timer.unit != 'ns' && applet) {
+      applet = destroyElement(applet);
+    }
+    // error if there are no working timers
+    if (timer.res == Infinity) {
+      throw new Error('Benchmark.js was unable to find a working timer.');
+    }
+    // use API of chosen timer
+    if (timer.unit == 'ns') {
+      if (timer.ns.nanoTime) {
+        extend(template, {
+          'begin': 's$=n$.nanoTime()',
+          'end': 'r$=(n$.nanoTime()-s$)/1e9'
+        });
+      } else {
+        extend(template, {
+          'begin': 's$=n$()',
+          'end': 'r$=n$(s$);r$=r$[0]+(r$[1]/1e9)'
+        });
+      }
+    }
+    else if (timer.unit == 'us') {
+      if (timer.ns.stop) {
+        extend(template, {
+          'begin': 's$=n$.start()',
+          'end': 'r$=n$.microseconds()/1e6'
+        });
+      } else if (perfName) {
+        extend(template, {
+          'begin': 's$=n$.' + perfName + '()',
+          'end': 'r$=(n$.' + perfName + '()-s$)/1e3'
+        });
+      } else {
+        extend(template, {
+          'begin': 's$=n$()',
+          'end': 'r$=(n$()-s$)/1e6'
+        });
+      }
+    }
+
+    // define `timer` methods
+    timer.start = createFunction(preprocess('o$'),
+      preprocess('var n$=this.ns,#{begin};o$.elapsed=0;o$.timeStamp=s$'));
+
+    timer.stop = createFunction(preprocess('o$'),
+      preprocess('var n$=this.ns,s$=o$.timeStamp,#{end};o$.elapsed=r$'));
+
+    // resolve time span required to achieve a percent uncertainty of at most 1%
+    // http://spiff.rit.edu/classes/phys273/uncert/uncert.html
+    options.minTime || (options.minTime = max(timer.res / 2 / 0.01, 0.05));
+    return clock.apply(null, arguments);
+  }
+
+  /*--------------------------------------------------------------------------*/
+
+  /**
+   * Computes stats on benchmark results.
+   *
+   * @private
+   * @param {Object} bench The benchmark instance.
+   * @param {Object} options The options object.
+   */
+  function compute(bench, options) {
+    options || (options = {});
+
+    var async = options.async,
+        elapsed = 0,
+        initCount = bench.initCount,
+        minSamples = bench.minSamples,
+        queue = [],
+        sample = bench.stats.sample;
+
+    /**
+     * Adds a clone to the queue.
+     */
+    function enqueue() {
+      queue.push(bench.clone({
+        '_original': bench,
+        'events': {
+          'abort': [update],
+          'cycle': [update],
+          'error': [update],
+          'start': [update]
+        }
+      }));
+    }
+
+    /**
+     * Updates the clone/original benchmarks to keep their data in sync.
+     */
+    function update(event) {
+      var clone = this,
+          type = event.type;
+
+      if (bench.running) {
+        if (type == 'start') {
+          // Note: `clone.minTime` prop is inited in `clock()`
+          clone.count = bench.initCount;
+        }
+        else {
+          if (type == 'error') {
+            bench.error = clone.error;
+          }
+          if (type == 'abort') {
+            bench.abort();
+            bench.emit('cycle');
+          } else {
+            event.currentTarget = event.target = bench;
+            bench.emit(event);
+          }
+        }
+      } else if (bench.aborted) {
+        // clear abort listeners to avoid triggering bench's abort/cycle again
+        clone.events.abort.length = 0;
+        clone.abort();
+      }
+    }
+
+    /**
+     * Determines if more clones should be queued or if cycling should stop.
+     */
+    function evaluate(event) {
+      var critical,
+          df,
+          mean,
+          moe,
+          rme,
+          sd,
+          sem,
+          variance,
+          clone = event.target,
+          done = bench.aborted,
+          now = +new Date,
+          size = sample.push(clone.times.period),
+          maxedOut = size >= minSamples && (elapsed += now - clone.times.timeStamp) / 1e3 > bench.maxTime,
+          times = bench.times,
+          varOf = function(sum, x) { return sum + pow(x - mean, 2); };
+
+      // exit early for aborted or unclockable tests
+      if (done || clone.hz == Infinity) {
+        maxedOut = !(size = sample.length = queue.length = 0);
+      }
+
+      if (!done) {
+        // sample mean (estimate of the population mean)
+        mean = getMean(sample);
+        // sample variance (estimate of the population variance)
+        variance = reduce(sample, varOf, 0) / (size - 1) || 0;
+        // sample standard deviation (estimate of the population standard deviation)
+        sd = sqrt(variance);
+        // standard error of the mean (a.k.a. the standard deviation of the sampling distribution of the sample mean)
+        sem = sd / sqrt(size);
+        // degrees of freedom
+        df = size - 1;
+        // critical value
+        critical = tTable[Math.round(df) || 1] || tTable.infinity;
+        // margin of error
+        moe = sem * critical;
+        // relative margin of error
+        rme = (moe / mean) * 100 || 0;
+
+        extend(bench.stats, {
+          'deviation': sd,
+          'mean': mean,
+          'moe': moe,
+          'rme': rme,
+          'sem': sem,
+          'variance': variance
+        });
+
+        // Abort the cycle loop when the minimum sample size has been collected
+        // and the elapsed time exceeds the maximum time allowed per benchmark.
+        // We don't count cycle delays toward the max time because delays may be
+        // increased by browsers that clamp timeouts for inactive tabs.
+        // https://developer.mozilla.org/en/window.setTimeout#Inactive_tabs
+        if (maxedOut) {
+          // reset the `initCount` in case the benchmark is rerun
+          bench.initCount = initCount;
+          bench.running = false;
+          done = true;
+          times.elapsed = (now - times.timeStamp) / 1e3;
+        }
+        if (bench.hz != Infinity) {
+          bench.hz = 1 / mean;
+          times.cycle = mean * bench.count;
+          times.period = mean;
+        }
+      }
+      // if time permits, increase sample size to reduce the margin of error
+      if (queue.length < 2 && !maxedOut) {
+        enqueue();
+      }
+      // abort the invoke cycle when done
+      event.aborted = done;
+    }
+
+    // init queue and begin
+    enqueue();
+    invoke(queue, {
+      'name': 'run',
+      'args': { 'async': async },
+      'queued': true,
+      'onCycle': evaluate,
+      'onComplete': function() { bench.emit('complete'); }
+    });
+  }
+
+  /*--------------------------------------------------------------------------*/
+
+  /**
+   * Cycles a benchmark until a run `count` can be established.
+   *
+   * @private
+   * @param {Object} clone The cloned benchmark instance.
+   * @param {Object} options The options object.
+   */
+  function cycle(clone, options) {
+    options || (options = {});
+
+    var deferred;
+    if (clone instanceof Deferred) {
+      deferred = clone;
+      clone = clone.benchmark;
+    }
+
+    var clocked,
+        cycles,
+        divisor,
+        event,
+        minTime,
+        period,
+        async = options.async,
+        bench = clone._original,
+        count = clone.count,
+        times = clone.times;
+
+    // continue, if not aborted between cycles
+    if (clone.running) {
+      // `minTime` is set to `Benchmark.options.minTime` in `clock()`
+      cycles = ++clone.cycles;
+      clocked = deferred ? deferred.elapsed : clock(clone);
+      minTime = clone.minTime;
+
+      if (cycles > bench.cycles) {
+        bench.cycles = cycles;
+      }
+      if (clone.error) {
+        event = Event('error');
+        event.message = clone.error;
+        clone.emit(event);
+        if (!event.cancelled) {
+          clone.abort();
+        }
+      }
+    }
+
+    // continue, if not errored
+    if (clone.running) {
+      // time taken to complete last test cycle
+      bench.times.cycle = times.cycle = clocked;
+      // seconds per operation
+      period = bench.times.period = times.period = clocked / count;
+      // ops per second
+      bench.hz = clone.hz = 1 / period;
+      // avoid working our way up to this next time
+      bench.initCount = clone.initCount = count;
+      // do we need to do another cycle?
+      clone.running = clocked < minTime;
+
+      if (clone.running) {
+        // tests may clock at `0` when `initCount` is a small number,
+        // to avoid that we set its count to something a bit higher
+        if (!clocked && (divisor = divisors[clone.cycles]) != null) {
+          count = floor(4e6 / divisor);
+        }
+        // calculate how many more iterations it will take to achive the `minTime`
+        if (count <= clone.count) {
+          count += Math.ceil((minTime - clocked) / period);
+        }
+        clone.running = count != Infinity;
+      }
+    }
+    // should we exit early?
+    event = Event('cycle');
+    clone.emit(event);
+    if (event.aborted) {
+      clone.abort();
+    }
+    // figure out what to do next
+    if (clone.running) {
+      // start a new cycle
+      clone.count = count;
+      if (deferred) {
+        clone.compiled.call(deferred, timer);
+      } else if (async) {
+        delay(clone, function() { cycle(clone, options); });
+      } else {
+        cycle(clone);
+      }
+    }
+    else {
+      // fix TraceMonkey bug associated with clock fallbacks
+      // http://bugzil.la/509069
+      if (support.browser) {
+        runScript(uid + '=1;delete ' + uid);
+      }
+      // done
+      clone.emit('complete');
+    }
+  }
+
+  /*--------------------------------------------------------------------------*/
+
+  /**
+   * Runs the benchmark.
+   *
+   * @memberOf Benchmark
+   * @param {Object} [options={}] Options object.
+   * @returns {Object} The benchmark instance.
+   * @example
+   *
+   * // basic usage
+   * bench.run();
+   *
+   * // or with options
+   * bench.run({ 'async': true });
+   */
+  function run(options) {
+    var me = this,
+        event = Event('start');
+
+    // set `running` to `false` so `reset()` won't call `abort()`
+    me.running = false;
+    me.reset();
+    me.running = true;
+
+    me.count = me.initCount;
+    me.times.timeStamp = +new Date;
+    me.emit(event);
+
+    if (!event.cancelled) {
+      options = { 'async': ((options = options && options.async) == null ? me.async : options) && support.timeout };
+
+      // for clones created within `compute()`
+      if (me._original) {
+        if (me.defer) {
+          Deferred(me);
+        } else {
+          cycle(me, options);
+        }
+      }
+      // for original benchmarks
+      else {
+        compute(me, options);
+      }
+    }
+    return me;
+  }
+
+  /*--------------------------------------------------------------------------*/
+
+  // Firefox 1 erroneously defines variable and argument names of functions on
+  // the function itself as non-configurable properties with `undefined` values.
+  // The bugginess continues as the `Benchmark` constructor has an argument
+  // named `options` and Firefox 1 will not assign a value to `Benchmark.options`,
+  // making it non-writable in the process, unless it is the first property
+  // assigned by for-in loop of `extend()`.
+  extend(Benchmark, {
+
+    /**
+     * The default options copied by benchmark instances.
+     *
+     * @static
+     * @memberOf Benchmark
+     * @type Object
+     */
+    'options': {
+
+      /**
+       * A flag to indicate that benchmark cycles will execute asynchronously
+       * by default.
+       *
+       * @memberOf Benchmark.options
+       * @type Boolean
+       */
+      'async': false,
+
+      /**
+       * A flag to indicate that the benchmark clock is deferred.
+       *
+       * @memberOf Benchmark.options
+       * @type Boolean
+       */
+      'defer': false,
+
+      /**
+       * The delay between test cycles (secs).
+       * @memberOf Benchmark.options
+       * @type Number
+       */
+      'delay': 0.005,
+
+      /**
+       * Displayed by Benchmark#toString when a `name` is not available
+       * (auto-generated if absent).
+       *
+       * @memberOf Benchmark.options
+       * @type String
+       */
+      'id': undefined,
+
+      /**
+       * The default number of times to execute a test on a benchmark's first cycle.
+       *
+       * @memberOf Benchmark.options
+       * @type Number
+       */
+      'initCount': 1,
+
+      /**
+       * The maximum time a benchmark is allowed to run before finishing (secs).
+       *
+       * Note: Cycle delays aren't counted toward the maximum time.
+       *
+       * @memberOf Benchmark.options
+       * @type Number
+       */
+      'maxTime': 5,
+
+      /**
+       * The minimum sample size required to perform statistical analysis.
+       *
+       * @memberOf Benchmark.options
+       * @type Number
+       */
+      'minSamples': 5,
+
+      /**
+       * The time needed to reduce the percent uncertainty of measurement to 1% (secs).
+       *
+       * @memberOf Benchmark.options
+       * @type Number
+       */
+      'minTime': 0,
+
+      /**
+       * The name of the benchmark.
+       *
+       * @memberOf Benchmark.options
+       * @type String
+       */
+      'name': undefined,
+
+      /**
+       * An event listener called when the benchmark is aborted.
+       *
+       * @memberOf Benchmark.options
+       * @type Function
+       */
+      'onAbort': undefined,
+
+      /**
+       * An event listener called when the benchmark completes running.
+       *
+       * @memberOf Benchmark.options
+       * @type Function
+       */
+      'onComplete': undefined,
+
+      /**
+       * An event listener called after each run cycle.
+       *
+       * @memberOf Benchmark.options
+       * @type Function
+       */
+      'onCycle': undefined,
+
+      /**
+       * An event listener called when a test errors.
+       *
+       * @memberOf Benchmark.options
+       * @type Function
+       */
+      'onError': undefined,
+
+      /**
+       * An event listener called when the benchmark is reset.
+       *
+       * @memberOf Benchmark.options
+       * @type Function
+       */
+      'onReset': undefined,
+
+      /**
+       * An event listener called when the benchmark starts running.
+       *
+       * @memberOf Benchmark.options
+       * @type Function
+       */
+      'onStart': undefined
+    },
+
+    /**
+     * Platform object with properties describing things like browser name,
+     * version, and operating system.
+     *
+     * @static
+     * @memberOf Benchmark
+     * @type Object
+     */
+    'platform': req('platform') || window.platform || {
+
+      /**
+       * The platform description.
+       *
+       * @memberOf Benchmark.platform
+       * @type String
+       */
+      'description': window.navigator && navigator.userAgent || null,
+
+      /**
+       * The name of the browser layout engine.
+       *
+       * @memberOf Benchmark.platform
+       * @type String|Null
+       */
+      'layout': null,
+
+      /**
+       * The name of the product hosting the browser.
+       *
+       * @memberOf Benchmark.platform
+       * @type String|Null
+       */
+      'product': null,
+
+      /**
+       * The name of the browser/environment.
+       *
+       * @memberOf Benchmark.platform
+       * @type String|Null
+       */
+      'name': null,
+
+      /**
+       * The name of the product's manufacturer.
+       *
+       * @memberOf Benchmark.platform
+       * @type String|Null
+       */
+      'manufacturer': null,
+
+      /**
+       * The name of the operating system.
+       *
+       * @memberOf Benchmark.platform
+       * @type String|Null
+       */
+      'os': null,
+
+      /**
+       * The alpha/beta release indicator.
+       *
+       * @memberOf Benchmark.platform
+       * @type String|Null
+       */
+      'prerelease': null,
+
+      /**
+       * The browser/environment version.
+       *
+       * @memberOf Benchmark.platform
+       * @type String|Null
+       */
+      'version': null,
+
+      /**
+       * Return platform description when the platform object is coerced to a string.
+       *
+       * @memberOf Benchmark.platform
+       * @type Function
+       * @returns {String} The platform description.
+       */
+      'toString': function() {
+        return this.description || '';
+      }
+    },
+
+    /**
+     * The semantic version number.
+     *
+     * @static
+     * @memberOf Benchmark
+     * @type String
+     */
+    'version': '1.0.0',
+
+    // an object of environment/feature detection flags
+    'support': support,
+
+    // clone objects
+    'deepClone': deepClone,
+
+    // iteration utility
+    'each': each,
+
+    // augment objects
+    'extend': extend,
+
+    // generic Array#filter
+    'filter': filter,
+
+    // generic Array#forEach
+    'forEach': forEach,
+
+    // generic own property iteration utility
+    'forOwn': forOwn,
+
+    // converts a number to a comma-separated string
+    'formatNumber': formatNumber,
+
+    // generic Object#hasOwnProperty
+    // (trigger hasKey's lazy define before assigning it to Benchmark)
+    'hasKey': (hasKey(Benchmark, ''), hasKey),
+
+    // generic Array#indexOf
+    'indexOf': indexOf,
+
+    // template utility
+    'interpolate': interpolate,
+
+    // invokes a method on each item in an array
+    'invoke': invoke,
+
+    // generic Array#join for arrays and objects
+    'join': join,
+
+    // generic Array#map
+    'map': map,
+
+    // retrieves a property value from each item in an array
+    'pluck': pluck,
+
+    // generic Array#reduce
+    'reduce': reduce
+  });
+
+  /*--------------------------------------------------------------------------*/
+
+  extend(Benchmark.prototype, {
+
+    /**
+     * The number of times a test was executed.
+     *
+     * @memberOf Benchmark
+     * @type Number
+     */
+    'count': 0,
+
+    /**
+     * The number of cycles performed while benchmarking.
+     *
+     * @memberOf Benchmark
+     * @type Number
+     */
+    'cycles': 0,
+
+    /**
+     * The number of executions per second.
+     *
+     * @memberOf Benchmark
+     * @type Number
+     */
+    'hz': 0,
+
+    /**
+     * The compiled test function.
+     *
+     * @memberOf Benchmark
+     * @type Function|String
+     */
+    'compiled': undefined,
+
+    /**
+     * The error object if the test failed.
+     *
+     * @memberOf Benchmark
+     * @type Object
+     */
+    'error': undefined,
+
+    /**
+     * The test to benchmark.
+     *
+     * @memberOf Benchmark
+     * @type Function|String
+     */
+    'fn': undefined,
+
+    /**
+     * A flag to indicate if the benchmark is aborted.
+     *
+     * @memberOf Benchmark
+     * @type Boolean
+     */
+    'aborted': false,
+
+    /**
+     * A flag to indicate if the benchmark is running.
+     *
+     * @memberOf Benchmark
+     * @type Boolean
+     */
+    'running': false,
+
+    /**
+     * Compiled into the test and executed immediately **before** the test loop.
+     *
+     * @memberOf Benchmark
+     * @type Function|String
+     * @example
+     *
+     * // basic usage
+     * var bench = Benchmark({
+     *   'setup': function() {
+     *     var c = this.count,
+     *         element = document.getElementById('container');
+     *     while (c--) {
+     *       element.appendChild(document.createElement('div'));
+     *     }
+     *   },
+     *   'fn': function() {
+     *     element.removeChild(element.lastChild);
+     *   }
+     * });
+     *
+     * // compiles to something like:
+     * var c = this.count,
+     *     element = document.getElementById('container');
+     * while (c--) {
+     *   element.appendChild(document.createElement('div'));
+     * }
+     * var start = new Date;
+     * while (count--) {
+     *   element.removeChild(element.lastChild);
+     * }
+     * var end = new Date - start;
+     *
+     * // or using strings
+     * var bench = Benchmark({
+     *   'setup': '\
+     *     var a = 0;\n\
+     *     (function() {\n\
+     *       (function() {\n\
+     *         (function() {',
+     *   'fn': 'a += 1;',
+     *   'teardown': '\
+     *          }())\n\
+     *        }())\n\
+     *      }())'
+     * });
+     *
+     * // compiles to something like:
+     * var a = 0;
+     * (function() {
+     *   (function() {
+     *     (function() {
+     *       var start = new Date;
+     *       while (count--) {
+     *         a += 1;
+     *       }
+     *       var end = new Date - start;
+     *     }())
+     *   }())
+     * }())
+     */
+    'setup': noop,
+
+    /**
+     * Compiled into the test and executed immediately **after** the test loop.
+     *
+     * @memberOf Benchmark
+     * @type Function|String
+     */
+    'teardown': noop,
+
+    /**
+     * An object of stats including mean, margin or error, and standard deviation.
+     *
+     * @memberOf Benchmark
+     * @type Object
+     */
+    'stats': {
+
+      /**
+       * The margin of error.
+       *
+       * @memberOf Benchmark#stats
+       * @type Number
+       */
+      'moe': 0,
+
+      /**
+       * The relative margin of error (expressed as a percentage of the mean).
+       *
+       * @memberOf Benchmark#stats
+       * @type Number
+       */
+      'rme': 0,
+
+      /**
+       * The standard error of the mean.
+       *
+       * @memberOf Benchmark#stats
+       * @type Number
+       */
+      'sem': 0,
+
+      /**
+       * The sample standard deviation.
+       *
+       * @memberOf Benchmark#stats
+       * @type Number
+       */
+      'deviation': 0,
+
+      /**
+       * The sample arithmetic mean.
+       *
+       * @memberOf Benchmark#stats
+       * @type Number
+       */
+      'mean': 0,
+
+      /**
+       * The array of sampled periods.
+       *
+       * @memberOf Benchmark#stats
+       * @type Array
+       */
+      'sample': [],
+
+      /**
+       * The sample variance.
+       *
+       * @memberOf Benchmark#stats
+       * @type Number
+       */
+      'variance': 0
+    },
+
+    /**
+     * An object of timing data including cycle, elapsed, period, start, and stop.
+     *
+     * @memberOf Benchmark
+     * @type Object
+     */
+    'times': {
+
+      /**
+       * The time taken to complete the last cycle (secs).
+       *
+       * @memberOf Benchmark#times
+       * @type Number
+       */
+      'cycle': 0,
+
+      /**
+       * The time taken to complete the benchmark (secs).
+       *
+       * @memberOf Benchmark#times
+       * @type Number
+       */
+      'elapsed': 0,
+
+      /**
+       * The time taken to execute the test once (secs).
+       *
+       * @memberOf Benchmark#times
+       * @type Number
+       */
+      'period': 0,
+
+      /**
+       * A timestamp of when the benchmark started (ms).
+       *
+       * @memberOf Benchmark#times
+       * @type Number
+       */
+      'timeStamp': 0
+    },
+
+    // aborts benchmark (does not record times)
+    'abort': abort,
+
+    // creates a new benchmark using the same test and options
+    'clone': clone,
+
+    // compares benchmark's hertz with another
+    'compare': compare,
+
+    // executes listeners
+    'emit': emit,
+
+    // get listeners
+    'listeners': listeners,
+
+    // unregister listeners
+    'off': off,
+
+    // register listeners
+    'on': on,
+
+    // reset benchmark properties
+    'reset': reset,
+
+    // runs the benchmark
+    'run': run,
+
+    // pretty print benchmark info
+    'toString': toStringBench
+  });
+
+  /*--------------------------------------------------------------------------*/
+
+  extend(Deferred.prototype, {
+
+    /**
+     * The deferred benchmark instance.
+     *
+     * @memberOf Benchmark.Deferred
+     * @type Object
+     */
+    'benchmark': null,
+
+    /**
+     * The number of deferred cycles performed while benchmarking.
+     *
+     * @memberOf Benchmark.Deferred
+     * @type Number
+     */
+    'cycles': 0,
+
+    /**
+     * The time taken to complete the deferred benchmark (secs).
+     *
+     * @memberOf Benchmark.Deferred
+     * @type Number
+     */
+    'elapsed': 0,
+
+    /**
+     * A timestamp of when the deferred benchmark started (ms).
+     *
+     * @memberOf Benchmark.Deferred
+     * @type Number
+     */
+    'timeStamp': 0,
+
+    // cycles/completes the deferred benchmark
+    'resolve': resolve
+  });
+
+  /*--------------------------------------------------------------------------*/
+
+  extend(Event.prototype, {
+
+    /**
+     * A flag to indicate if the emitters listener iteration is aborted.
+     *
+     * @memberOf Benchmark.Event
+     * @type Boolean
+     */
+    'aborted': false,
+
+    /**
+     * A flag to indicate if the default action is cancelled.
+     *
+     * @memberOf Benchmark.Event
+     * @type Boolean
+     */
+    'cancelled': false,
+
+    /**
+     * The object whose listeners are currently being processed.
+     *
+     * @memberOf Benchmark.Event
+     * @type Object
+     */
+    'currentTarget': undefined,
+
+    /**
+     * The return value of the last executed listener.
+     *
+     * @memberOf Benchmark.Event
+     * @type Mixed
+     */
+    'result': undefined,
+
+    /**
+     * The object to which the event was originally emitted.
+     *
+     * @memberOf Benchmark.Event
+     * @type Object
+     */
+    'target': undefined,
+
+    /**
+     * A timestamp of when the event was created (ms).
+     *
+     * @memberOf Benchmark.Event
+     * @type Number
+     */
+    'timeStamp': 0,
+
+    /**
+     * The event type.
+     *
+     * @memberOf Benchmark.Event
+     * @type String
+     */
+    'type': ''
+  });
+
+  /*--------------------------------------------------------------------------*/
+
+  /**
+   * The default options copied by suite instances.
+   *
+   * @static
+   * @memberOf Benchmark.Suite
+   * @type Object
+   */
+  Suite.options = {
+
+    /**
+     * The name of the suite.
+     *
+     * @memberOf Benchmark.Suite.options
+     * @type String
+     */
+    'name': undefined
+  };
+
+  /*--------------------------------------------------------------------------*/
+
+  extend(Suite.prototype, {
+
+    /**
+     * The number of benchmarks in the suite.
+     *
+     * @memberOf Benchmark.Suite
+     * @type Number
+     */
+    'length': 0,
+
+    /**
+     * A flag to indicate if the suite is aborted.
+     *
+     * @memberOf Benchmark.Suite
+     * @type Boolean
+     */
+    'aborted': false,
+
+    /**
+     * A flag to indicate if the suite is running.
+     *
+     * @memberOf Benchmark.Suite
+     * @type Boolean
+     */
+    'running': false,
+
+    /**
+     * An `Array#forEach` like method.
+     * Callbacks may terminate the loop by explicitly returning `false`.
+     *
+     * @memberOf Benchmark.Suite
+     * @param {Function} callback The function called per iteration.
+     * @returns {Object} The suite iterated over.
+     */
+    'forEach': methodize(forEach),
+
+    /**
+     * An `Array#indexOf` like method.
+     *
+     * @memberOf Benchmark.Suite
+     * @param {Mixed} value The value to search for.
+     * @returns {Number} The index of the matched value or `-1`.
+     */
+    'indexOf': methodize(indexOf),
+
+    /**
+     * Invokes a method on all benchmarks in the suite.
+     *
+     * @memberOf Benchmark.Suite
+     * @param {String|Object} name The name of the method to invoke OR options object.
+     * @param {Mixed} [arg1, arg2, ...] Arguments to invoke the method with.
+     * @returns {Array} A new array of values returned from each method invoked.
+     */
+    'invoke': methodize(invoke),
+
+    /**
+     * Converts the suite of benchmarks to a string.
+     *
+     * @memberOf Benchmark.Suite
+     * @param {String} [separator=','] A string to separate each element of the array.
+     * @returns {String} The string.
+     */
+    'join': [].join,
+
+    /**
+     * An `Array#map` like method.
+     *
+     * @memberOf Benchmark.Suite
+     * @param {Function} callback The function called per iteration.
+     * @returns {Array} A new array of values returned by the callback.
+     */
+    'map': methodize(map),
+
+    /**
+     * Retrieves the value of a specified property from all benchmarks in the suite.
+     *
+     * @memberOf Benchmark.Suite
+     * @param {String} property The property to pluck.
+     * @returns {Array} A new array of property values.
+     */
+    'pluck': methodize(pluck),
+
+    /**
+     * Removes the last benchmark from the suite and returns it.
+     *
+     * @memberOf Benchmark.Suite
+     * @returns {Mixed} The removed benchmark.
+     */
+    'pop': [].pop,
+
+    /**
+     * Appends benchmarks to the suite.
+     *
+     * @memberOf Benchmark.Suite
+     * @returns {Number} The suite's new length.
+     */
+    'push': [].push,
+
+    /**
+     * Sorts the benchmarks of the suite.
+     *
+     * @memberOf Benchmark.Suite
+     * @param {Function} [compareFn=null] A function that defines the sort order.
+     * @returns {Object} The sorted suite.
+     */
+    'sort': [].sort,
+
+    /**
+     * An `Array#reduce` like method.
+     *
+     * @memberOf Benchmark.Suite
+     * @param {Function} callback The function called per iteration.
+     * @param {Mixed} accumulator Initial value of the accumulator.
+     * @returns {Mixed} The accumulator.
+     */
+    'reduce': methodize(reduce),
+
+    // aborts all benchmarks in the suite
+    'abort': abortSuite,
+
+    // adds a benchmark to the suite
+    'add': add,
+
+    // creates a new suite with cloned benchmarks
+    'clone': cloneSuite,
+
+    // executes listeners of a specified type
+    'emit': emit,
+
+    // creates a new suite of filtered benchmarks
+    'filter': filterSuite,
+
+    // get listeners
+    'listeners': listeners,
+
+    // unregister listeners
+    'off': off,
+
+   // register listeners
+    'on': on,
+
+    // resets all benchmarks in the suite
+    'reset': resetSuite,
+
+    // runs all benchmarks in the suite
+    'run': runSuite,
+
+    // array methods
+    'concat': concat,
+
+    'reverse': reverse,
+
+    'shift': shift,
+
+    'slice': slice,
+
+    'splice': splice,
+
+    'unshift': unshift
+  });
+
+  /*--------------------------------------------------------------------------*/
+
+  // expose Deferred, Event and Suite
+  extend(Benchmark, {
+    'Deferred': Deferred,
+    'Event': Event,
+    'Suite': Suite
+  });
+
+  // expose Benchmark
+  // some AMD build optimizers, like r.js, check for specific condition patterns like the following:
+  if (typeof define == 'function' && typeof define.amd == 'object' && define.amd) {
+    // define as an anonymous module so, through path mapping, it can be aliased
+    define(function() {
+      return Benchmark;
+    });
+  }
+  // check for `exports` after `define` in case a build optimizer adds an `exports` object
+  else if (freeExports) {
+    // in Node.js or RingoJS v0.8.0+
+    if (typeof module == 'object' && module && module.exports == freeExports) {
+      (module.exports = Benchmark).Benchmark = Benchmark;
+    }
+    // in Narwhal or RingoJS v0.7.0-
+    else {
+      freeExports.Benchmark = Benchmark;
+    }
+  }
+  // in a browser or Rhino
+  else {
+    // use square bracket notation so Closure Compiler won't munge `Benchmark`
+    // http://code.google.com/closure/compiler/docs/api-tutorial3.html#export
+    window['Benchmark'] = Benchmark;
+  }
+
+  // trigger clock's lazy define early to avoid a security error
+  if (support.air) {
+    clock({ '_original': { 'fn': noop, 'count': 1, 'options': {} } });
+  }
+}(this));

--- a/bench/src/PatternMatchBench.elm
+++ b/bench/src/PatternMatchBench.elm
@@ -1,0 +1,70 @@
+module PatternMatchBench where
+
+type NestedStructure = 
+    Nest Float (NestedStructure)
+  | End Float
+  
+
+intToNest : Int -> NestedStructure
+intToNest i = 
+  let
+    helper i accum =
+      case (i % 20) of
+        0 -> 
+          accum
+        
+        _ -> 
+          helper (i-1) <| Nest (toFloat <| i * i) accum 
+  in
+    helper i (End <| toFloat i)
+    
+deepMatchingFunction : NestedStructure -> Float
+deepMatchingFunction struct = 
+  case struct of
+    (Nest x1 (Nest x2 (Nest x3 (Nest x4 (Nest x5 (Nest x6 (Nest x7 (Nest x8 (Nest x9 (Nest x10 (Nest x11 (Nest x12 (Nest x13 (Nest x14 (Nest x15 (Nest x16 (Nest x17 (End x18 ) ) ) ) ) ) ) ) ) ) ) ) ) ) ) ) ) ) ->
+      x1 + x2 + x3 + x4 + x5 + x6 + x7 + x8 + x9 + x10 + x11 + x12 + x13 + x14 + x15 + x16 + x17 + x18
+    
+    Nest x _ -> 
+      x
+    
+    End x -> 
+      x
+      
+
+wildcardMatchingFunction : NestedStructure -> Float
+wildcardMatchingFunction struct = 
+  case struct of
+    (Nest x (Nest _ (Nest _ (Nest _ (Nest _ (Nest _ (Nest _ (Nest _ (Nest _ (Nest _ (Nest _ (Nest _ (Nest _ (Nest _ (Nest _ (Nest _ (Nest _ (End y ) ) ) ) ) ) ) ) ) ) ) ) ) ) ) ) ) ) ->
+      x + y + x + y + x + y + x + y + x + y + x + y + x + y + x + y + x + y
+    
+    Nest x _ -> 
+      x
+    
+    End x -> 
+      x
+      
+      
+shallowMatchingFunction : NestedStructure -> Float
+shallowMatchingFunction  struct = 
+  case struct of
+    (Nest x1 (Nest x2 (Nest x3 (End x4) ) ) ) ->
+      x1 + x2 + x3 + x4 + x1 + x2 + x3 + x4 + x1 + x2 + x3 + x4 + x1 + x2 + x3 + x4 + x1 + x2
+    
+    Nest x _ -> 
+      x
+    
+    End x -> 
+      x
+      
+sumStructures : (NestedStructure -> Float) -> List NestedStructure -> Float
+sumStructures f inList =
+  List.foldr (\x sumSoFar -> sumSoFar + f x) 0.0 inList
+  
+  
+deepMatchSum = sumStructures deepMatchingFunction
+
+
+shallowMatchSum = sumStructures shallowMatchingFunction
+
+
+wildcardMatchSum = sumStructures wildcardMatchingFunction

--- a/bench/src/RecordBench.elm
+++ b/bench/src/RecordBench.elm
@@ -1,0 +1,76 @@
+module RecordBench where
+
+type alias BigRecord = 
+  { myLargeNamedField1 : Float 
+  , myLargeNamedField2 : Float
+  , myLargeNamedField3 : Float
+  , myLargeNamedField4 : Float
+  , myLargeNamedField5 : Float
+  , myLargeNamedField6 : Float
+  , myLargeNamedField7 : Float
+  , myLargeNamedField8 : Float
+  , myLargeNamedField9 : Float
+  , myLargeNamedField10 : Float
+  , myLargeNamedField11 : Float
+  , myLargeNamedField12 : Float
+  , myLargeNamedField13 : Float
+  , myLargeNamedField14 : Float
+  , myLargeNamedField15 : Float
+  , myLargeNamedField16 : Float
+  , myLargeNamedField17 : Float
+  , myLargeNamedField18 : Float
+  , myLargeNamedField19 : Float
+  , myLargeNamedField20 : Float
+  }
+  
+defaultRec = 
+  BigRecord 1.0 2.0 3.0 4.0 5.0 6.0 7.0 8.0 9.0 10.0
+    11.0 12.0 13.0 14.0 15.0 16.0 17.0 18.0 19.0 20.0
+  
+getField i = 
+  case (i % 20) of
+    0 -> 
+      defaultRec.myLargeNamedField20
+    1 -> 
+      defaultRec.myLargeNamedField1
+    2 -> 
+      defaultRec.myLargeNamedField2
+    3 -> 
+      defaultRec.myLargeNamedField3
+    4 -> 
+      defaultRec.myLargeNamedField4
+    5 -> 
+      defaultRec.myLargeNamedField5
+    6 -> 
+      defaultRec.myLargeNamedField6
+    7 -> 
+      defaultRec.myLargeNamedField7
+    8 -> 
+      defaultRec.myLargeNamedField8
+    9 -> 
+      defaultRec.myLargeNamedField9
+    10 -> 
+      defaultRec.myLargeNamedField10
+    11 -> 
+      defaultRec.myLargeNamedField11
+    12 -> 
+      defaultRec.myLargeNamedField12
+    13 -> 
+      defaultRec.myLargeNamedField13
+    14 -> 
+      defaultRec.myLargeNamedField14
+    15 -> 
+      defaultRec.myLargeNamedField15
+    16 -> 
+      defaultRec.myLargeNamedField16
+    17 -> 
+      defaultRec.myLargeNamedField17
+    18 -> 
+      defaultRec.myLargeNamedField18
+    19 -> 
+      defaultRec.myLargeNamedField19
+      
+
+sumRandomElems : List Int -> Float
+sumRandomElems randomInts = 
+  List.foldr (\i sumSoFar -> (getField i) + sumSoFar ) 0.0 randomInts

--- a/bench/src/SmallCtorBench.elm
+++ b/bench/src/SmallCtorBench.elm
@@ -1,0 +1,76 @@
+module SmallCtorBench where
+
+type ManyCtors = 
+    MyLongNamedCtor1 Float Float Float
+  | MyLongNamedCtor2 Float Float
+  | MyLongNamedCtor3 Float Float Float
+  | MyLongNamedCtor4 Float Float
+  | MyLongNamedCtor5 Float Float Float
+  | MyLongNamedCtor6 Float Float
+  | MyLongNamedCtor7 Float Float Float
+  | MyLongNamedCtor8 Float Float
+  | MyLongNamedCtor9 Float Float Float
+  | MyLongNamedCtor10 Float Float
+  
+
+getFieldSum someData = 
+  case someData of
+    MyLongNamedCtor1 x y z ->
+      x + y + z
+    
+    MyLongNamedCtor3 x y z ->
+      x + y + z
+    
+    MyLongNamedCtor5 x y z ->
+      x + y + z
+    
+    MyLongNamedCtor7 x y z ->
+      x + y + z
+    
+    MyLongNamedCtor9 x y z ->
+      x + y + z
+
+    MyLongNamedCtor10 x y ->
+      x + y
+    
+    MyLongNamedCtor8 x y ->
+      x + y
+    
+    MyLongNamedCtor6 x y ->
+      x + y
+    
+    MyLongNamedCtor4 x y ->
+      x + y
+    
+    MyLongNamedCtor2 x y ->
+      x + y
+      
+
+makeRandomData i = 
+  case (i % 10) of
+    0 -> 
+      MyLongNamedCtor10 (toFloat i) (toFloat <| i*i)
+    1 -> 
+      MyLongNamedCtor1 (toFloat i) (toFloat <| i*i) (toFloat <| i*i*i)
+    2 -> 
+      MyLongNamedCtor2 (toFloat i) (toFloat <| i*i)
+    3 -> 
+      MyLongNamedCtor3 (toFloat i) (toFloat <| i*i) (toFloat <| i*i*i)
+    4 -> 
+      MyLongNamedCtor4 (toFloat i) (toFloat <| i*i)
+    5 -> 
+      MyLongNamedCtor5 (toFloat i) (toFloat <| i*i) (toFloat <| i*i*i)
+    6 -> 
+      MyLongNamedCtor6 (toFloat i) (toFloat <| i*i)
+    7 -> 
+      MyLongNamedCtor7 (toFloat i) (toFloat <| i*i) (toFloat <| i*i*i)
+    8 -> 
+      MyLongNamedCtor8 (toFloat i) (toFloat <| i*i)
+    9 -> 
+      MyLongNamedCtor9 (toFloat i) (toFloat <| i*i) (toFloat <| i*i*i)
+
+      
+
+sumFieldsList : List ManyCtors -> Float
+sumFieldsList dataList = 
+  List.foldr (\val sumSoFar -> (getFieldSum val) + sumSoFar ) 0.0 dataList

--- a/bench/src/SmallRecordBench.elm
+++ b/bench/src/SmallRecordBench.elm
@@ -1,0 +1,42 @@
+module SmallRecordBench where
+
+type alias SmallRecord = 
+  { myLargeNamedField1 : Float 
+  , myLargeNamedField2 : Float
+  , myLargeNamedField3 : Float
+  , myLargeNamedField4 : Float
+  , myLargeNamedField5 : Float
+  , myLargeNamedField6 : Float
+  , myLargeNamedField7 : Float
+  , myLargeNamedField8 : Float
+  , myLargeNamedField9 : Float
+  }
+  
+defaultRec = 
+  SmallRecord 1.0 2.0 3.0 4.0 5.0 6.0 7.0 8.0 9.0 
+  
+getField i = 
+  case (i % 9) of
+    1 -> 
+      defaultRec.myLargeNamedField1
+    2 -> 
+      defaultRec.myLargeNamedField2
+    3 -> 
+      defaultRec.myLargeNamedField3
+    4 -> 
+      defaultRec.myLargeNamedField4
+    5 -> 
+      defaultRec.myLargeNamedField5
+    6 -> 
+      defaultRec.myLargeNamedField6
+    7 -> 
+      defaultRec.myLargeNamedField7
+    8 -> 
+      defaultRec.myLargeNamedField8
+    0 -> 
+      defaultRec.myLargeNamedField9
+      
+
+sumRandomElems : List Int -> Float
+sumRandomElems randomInts = 
+  List.foldr (\i sumSoFar -> (getField i) + sumSoFar ) 0.0 randomInts

--- a/bench/src/SmallTupleBench.elm
+++ b/bench/src/SmallTupleBench.elm
@@ -1,0 +1,30 @@
+module SmallTupleBench where
+
+type alias SmallTuple = 
+  ( Float 
+  , Float
+  , Float
+  , Float
+  , Float
+  , Float
+  , Float
+  , Float
+  , Float
+  )
+  
+defaultTuple = 
+  (1.0, 2.0, 3.0)
+  
+getField (x1, x2, x3) i = 
+  case (i % 3) of
+    1 -> 
+      x1
+    2 -> 
+      x2
+    0 -> 
+      x3
+      
+
+sumRandomElems : List Int -> Float
+sumRandomElems randomInts = 
+  List.foldr (\i sumSoFar -> (getField defaultTuple i) + sumSoFar ) 0.0 randomInts

--- a/bench/src/TodoBench.elm
+++ b/bench/src/TodoBench.elm
@@ -1,0 +1,132 @@
+module TodoBench where
+
+import String
+
+---- MODEL ----
+
+-- The full application state of our todo app.
+type alias Model =
+    { tasks : List Task
+    , field : String
+    , uid : Int
+    , visibility : String
+    }
+
+
+type alias Task =
+    { description : String
+    , completed : Bool
+    , editing : Bool
+    , id : Int
+    }
+
+
+newTask : String -> Int -> Task
+newTask desc id =
+    { description = desc
+    , completed = False
+    , editing = False
+    , id = id
+    }
+
+
+emptyModel : Model
+emptyModel =
+    { tasks = []
+    , visibility = "All"
+    , field = ""
+    , uid = 0
+    }
+
+
+---- UPDATE ----
+
+-- A description of the kinds of actions that can be performed on the model of
+-- our application. See the following post for more info on this pattern and
+-- some alternatives: http://elm-lang.org/learn/Architecture.elm
+type Action
+    = NoOp
+    | UpdateField String
+    | EditingTask Int Bool
+    | UpdateTask Int String
+    | Add
+    | Delete Int
+    | DeleteComplete
+    | Check Int Bool
+    | CheckAll Bool
+    | ChangeVisibility String
+
+
+-- How we update our Model on a given Action?
+update : Action -> Model -> Model
+update action model =
+    case action of
+      NoOp -> model
+
+      Add ->
+          { model |
+              uid <- model.uid + 1,
+              field <- "",
+              tasks <-
+                  if String.isEmpty model.field
+                    then model.tasks
+                    else model.tasks ++ [newTask model.field model.uid]
+          }
+
+      UpdateField str ->
+          { model | field <- str }
+
+      EditingTask id isEditing ->
+          let updateTask t = if t.id == id then { t | editing <- isEditing } else t
+          in
+              { model | tasks <- List.map updateTask model.tasks }
+
+      UpdateTask id task ->
+          let updateTask t = if t.id == id then { t | description <- task } else t
+          in
+              { model | tasks <- List.map updateTask model.tasks }
+
+      Delete id ->
+          { model | tasks <- List.filter (\t -> t.id /= id) model.tasks }
+
+      DeleteComplete ->
+          { model | tasks <- List.filter (not << .completed) model.tasks }
+
+      Check id isCompleted ->
+          let updateTask t = if t.id == id then { t | completed <- isCompleted } else t
+          in
+              { model | tasks <- List.map updateTask model.tasks }
+
+      CheckAll isCompleted ->
+          let updateTask t = { t | completed <- isCompleted }
+          in
+              { model | tasks <- List.map updateTask model.tasks }
+
+      ChangeVisibility visibility ->
+          { model | visibility <- visibility }
+          
+testActions = 
+  List.concat
+  [ List.concatMap --Add 50 tasks 
+      (\i -> [UpdateField <| "My task " ++ toString i, Add]) [1 .. 50]
+  , [CheckAll True] --Check them all
+  , [CheckAll False] --Uncheck them all
+  , List.concatMap --Alter the text of even numbered tasks
+      (\i -> [EditingTask i True, UpdateTask i "New Task text", Add] ) <| List.filter (\x -> x % 2 == 0 ) [1 .. 50]
+  --Check and uncheck some more tasks
+  , [Check 5 True, Check 7 True, Check 9 True, Check 13 True, Check 17 True, Check 23 True, Check 37 True]
+  , [Check 7 False, Check 13 False, Check 23 False, Check 37 False]
+  , [DeleteComplete] --Delete our checked tasks
+  , [Delete 7, Delete 23] --Delete a few more tasks
+  , List.concatMap --Add a few more tasks
+      (\i -> [UpdateField <| "Second batch task " ++ toString i, Add]) [51 .. 80]
+  , List.map --Check off and delete every other task
+      (\i -> Check i True ) <| List.filter List.filter (\x -> x % 2 == 0 ) [1 .. 80]
+  , [DeleteComplete]
+  , [CheckAll True, DeleteComplete] --Check and delete the remaining tasks
+  ]
+
+  
+evalActions : List Action -> Model
+evalActions actions = 
+  List.foldr update emptyModel actions

--- a/bench/src/TodoBench.elm
+++ b/bench/src/TodoBench.elm
@@ -121,7 +121,7 @@ testActions =
   , List.concatMap --Add a few more tasks
       (\i -> [UpdateField <| "Second batch task " ++ toString i, Add]) [51 .. 80]
   , List.map --Check off and delete every other task
-      (\i -> Check i True ) <| List.filter List.filter (\x -> x % 2 == 0 ) [1 .. 80]
+      (\i -> Check i True ) <| List.filter (\x -> x % 2 == 0 ) [1 .. 80]
   , [DeleteComplete]
   , [CheckAll True, DeleteComplete] --Check and delete the remaining tasks
   ]

--- a/bench/src/TupleBench.elm
+++ b/bench/src/TupleBench.elm
@@ -1,0 +1,42 @@
+module TupleBench where
+
+type alias BigTuple = 
+  ( Float 
+  , Float
+  , Float
+  , Float
+  , Float
+  , Float
+  , Float
+  , Float
+  , Float
+  )
+  
+defaultTuple = 
+  (1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0)
+  
+getField (x1, x2, x3, x4, x5, x6, x7, x8, x9) i = 
+  case (i % 9) of
+    1 -> 
+      x1
+    2 -> 
+      x2
+    3 -> 
+      x3
+    4 -> 
+      x4
+    5 -> 
+      x5
+    6 -> 
+      x6
+    7 -> 
+      x7
+    8 -> 
+      x8
+    0 -> 
+      x9
+      
+
+sumRandomElems : List Int -> Float
+sumRandomElems randomInts = 
+  List.foldr (\i sumSoFar -> (getField defaultTuple i) + sumSoFar ) 0.0 randomInts


### PR DESCRIPTION
Add a benchmark suite to elm-compiler.

To test a particular elm version, just do
`elm make CompilerBenchmarks.elm --output=Benchmark.html` with whatever version of Elm you are testing, then load the resulting Html page in your browser.