### PR TITLE
Common package module (take 2)

### DIFF
--- a/elm-compiler.cabal
+++ b/elm-compiler.cabal
@@ -41,7 +41,9 @@ Library
         Elm.Compiler,
         Elm.Compiler.Module,
         Elm.Compiler.Type,
+        Elm.Compiler.Version,
         Elm.Docs,
+        Elm.Package,
         Elm.Utils
 
     other-modules:
@@ -70,10 +72,8 @@ Library
         Docs.AST,
         Docs.Centralize,
         Docs.Check,
-        Elm.Package,
         Elm.Compiler.Imports,
         Elm.Compiler.Type.Extract,
-        Elm.Compiler.Version,
         Generate.JavaScript,
         Generate.JavaScript.Crash,
         Generate.JavaScript.Helpers,

--- a/elm-compiler.cabal
+++ b/elm-compiler.cabal
@@ -164,7 +164,12 @@ Executable elm
 
     Build-depends:
         base >=4.2 && <5,
+        aeson >= 0.7 && < 0.9,
+        binary >= 0.7.0.0 && < 0.8,
         directory >= 1.0 && < 2.0,
+        filepath >= 1 && < 2.0,
+        mtl >= 2.2 && < 3,
+        text >= 1 && < 2,
         process
 
 

--- a/elm-compiler.cabal
+++ b/elm-compiler.cabal
@@ -1,4 +1,3 @@
-
 Name: elm-compiler
 Version: 0.15.1
 
@@ -71,6 +70,7 @@ Library
         Docs.AST,
         Docs.Centralize,
         Docs.Check,
+        Elm.Package,
         Elm.Compiler.Imports,
         Elm.Compiler.Type.Extract,
         Elm.Compiler.Version,

--- a/elm-compiler.cabal
+++ b/elm-compiler.cabal
@@ -42,7 +42,6 @@ Library
         Elm.Compiler,
         Elm.Compiler.Module,
         Elm.Compiler.Type,
-        Elm.Compiler.Version,
         Elm.Docs,
         Elm.Package,
         Elm.Utils
@@ -75,6 +74,7 @@ Library
         Docs.Check,
         Elm.Compiler.Imports,
         Elm.Compiler.Type.Extract,
+        Elm.Compiler.Version,
         Generate.JavaScript,
         Generate.JavaScript.Crash,
         Generate.JavaScript.Helpers,

--- a/elm-compiler.cabal
+++ b/elm-compiler.cabal
@@ -1,3 +1,4 @@
+
 Name: elm-compiler
 Version: 0.15.1
 

--- a/src/AST/Module.hs
+++ b/src/AST/Module.hs
@@ -21,6 +21,7 @@ import qualified AST.Expression.Optimized as Optimized
 import qualified AST.Type as Type
 import qualified AST.Variable as Var
 import qualified Docs.AST as Docs
+import qualified Elm.Package as Package
 import qualified Elm.Compiler.Version as Compiler
 import qualified Reporting.Annotation as A
 
@@ -142,7 +143,7 @@ toInterface :: CanonicalModule -> Interface
 toInterface modul =
     let body' = body modul in
     Interface
-    { iVersion  = Compiler.version
+    { iVersion  = Package.versionToString Compiler.version
     , iExports  = exports modul
     , iTypes    = types body'
     , iImports  = imports modul

--- a/src/CommandLineRouter.hs
+++ b/src/CommandLineRouter.hs
@@ -7,7 +7,7 @@ import System.IO (hPutStrLn, stderr, stdin, stdout)
 import qualified System.Process as Proc
 
 import qualified Elm.Compiler.Version as Compiler
-
+import qualified Elm.Package as Pkg
 
 main :: IO ()
 main =
@@ -47,7 +47,7 @@ attemptToRun command args =
 
 usageMessage :: String
 usageMessage =
-  "Elm Platform " ++ Compiler.version ++ " - a way to run all Elm tools\n\
+  "Elm Platform " ++ (Pkg.versionToString Compiler.version) ++ " - a way to run all Elm tools\n\
   \\n\
   \Usage: elm <command> [<args>]\n\
   \\n\

--- a/src/Compile.hs
+++ b/src/Compile.hs
@@ -5,6 +5,7 @@ import qualified Data.Map as Map
 import qualified AST.Module as Module
 import qualified Canonicalize
 import Elm.Utils ((|>))
+import qualified Elm.Package as Package
 import qualified Nitpick.PatternMatches as Nitpick
 import qualified Nitpick.TopLevelTypes as Nitpick
 import qualified Parse.Helpers as Parse
@@ -16,19 +17,18 @@ import qualified Type.Inference as TI
 
 
 compile
-    :: String
-    -> String
+    :: Package.Name
     -> Bool
     -> Module.Interfaces
     -> String
     -> Result.Result Warning.Warning Error.Error Module.CanonicalModule
 
-compile user projectName isRoot interfaces source =
+compile packageName isRoot interfaces source =
   do
       -- determine if default imports should be added
       -- only elm-lang/core is exempt
       let needsDefaults =
-            not (user == "elm-lang" && projectName == "core")
+            not (packageName == Package.Name "elm-lang" "core")
 
       -- Parse the source code
       validModule <-

--- a/src/Compile.hs
+++ b/src/Compile.hs
@@ -28,7 +28,7 @@ compile packageName isRoot interfaces source =
       -- determine if default imports should be added
       -- only elm-lang/core is exempt
       let needsDefaults =
-            not (packageName == Package.Name "elm-lang" "core")
+            not (packageName == Package.coreName)
 
       -- Parse the source code
       validModule <-

--- a/src/Elm/Compiler.hs
+++ b/src/Elm/Compiler.hs
@@ -1,6 +1,7 @@
 {-# OPTIONS_GHC -Wall #-}
 module Elm.Compiler
-    ( parseDependencies
+    ( version
+    , parseDependencies
     , compile, Context(..), Result(..)
     , Dealiaser, dummyDealiaser
     , Error, errorToString, errorToJson, printError
@@ -13,6 +14,7 @@ import qualified Data.Map as Map
 import qualified AST.Module as Module
 import qualified Compile
 import qualified Docs.Check as Docs
+import qualified Elm.Compiler.Version
 import qualified Elm.Compiler.Module as PublicModule
 import qualified Elm.Docs as Docs
 import qualified Elm.Package as Package
@@ -25,6 +27,13 @@ import qualified Reporting.Error as Error
 import qualified Reporting.PrettyPrint as P
 import qualified Reporting.Result as Result
 import qualified Reporting.Warning as Warning
+
+
+-- VERSION
+
+version :: Package.Version
+version =
+  Elm.Compiler.Version.version
 
 
 -- DEPENDENCIES

--- a/src/Elm/Compiler.hs
+++ b/src/Elm/Compiler.hs
@@ -1,7 +1,6 @@
 {-# OPTIONS_GHC -Wall #-}
 module Elm.Compiler
-    ( version, rawVersion
-    , parseDependencies
+    ( parseDependencies
     , compile, Context(..), Result(..)
     , Dealiaser, dummyDealiaser
     , Error, errorToString, errorToJson, printError
@@ -15,7 +14,6 @@ import qualified AST.Module as Module
 import qualified Compile
 import qualified Docs.Check as Docs
 import qualified Elm.Compiler.Module as PublicModule
-import qualified Elm.Compiler.Version as Version
 import qualified Elm.Docs as Docs
 import qualified Elm.Package as Package
 import qualified Generate.JavaScript as JS
@@ -27,18 +25,6 @@ import qualified Reporting.Error as Error
 import qualified Reporting.PrettyPrint as P
 import qualified Reporting.Result as Result
 import qualified Reporting.Warning as Warning
-
-
--- VERSION
-
-version :: String
-version =
-    Version.version
-
-
-rawVersion :: [Int]
-rawVersion =
-    Version.rawVersion
 
 
 -- DEPENDENCIES

--- a/src/Elm/Compiler.hs
+++ b/src/Elm/Compiler.hs
@@ -17,6 +17,7 @@ import qualified Docs.Check as Docs
 import qualified Elm.Compiler.Module as PublicModule
 import qualified Elm.Compiler.Version as Version
 import qualified Elm.Docs as Docs
+import qualified Elm.Package as Package
 import qualified Generate.JavaScript as JS
 import qualified Optimize
 import qualified Parse.Module as Parse
@@ -72,14 +73,14 @@ compile
 
 compile context source interfaces =
   let
-    (Context user packageName isRoot isExposed) =
+    (Context packageName isRoot isExposed) =
       context
 
     unwrappedInterfaces =
       Map.mapKeysMonotonic (\(PublicModule.Name name) -> name) interfaces
 
     (Result.Result (dealiaser, warnings) rawResult) =
-      do  modul <- Compile.compile user packageName isRoot unwrappedInterfaces source
+      do  modul <- Compile.compile packageName isRoot unwrappedInterfaces source
           docs <- docsGen isExposed modul
 
           let interface = Module.toInterface modul
@@ -95,8 +96,7 @@ compile context source interfaces =
 
 
 data Context = Context
-    { _user :: String
-    , _packageName :: String
+    { _packageName :: Package.Name
     , _isRoot :: Bool
     , _isExposed :: Bool
     }

--- a/src/Elm/Compiler/Version.hs
+++ b/src/Elm/Compiler/Version.hs
@@ -1,21 +1,17 @@
 {-# OPTIONS_GHC -Wall #-}
-module Elm.Compiler.Version (version, elm) where
+module Elm.Compiler.Version (version) where
 
 import qualified Data.Version as Version
 import qualified Paths_elm_compiler as This
 import Elm.Package
-
-version :: String
-version =
-    Version.showVersion This.version
 
 
 rawVersion :: [Int]
 rawVersion =
     Version.versionBranch This.version
 
-elm :: Version
-elm =
+version :: Version
+version =
   case rawVersion of
     major : minor : patch : _ ->
         Version major minor patch

--- a/src/Elm/Compiler/Version.hs
+++ b/src/Elm/Compiler/Version.hs
@@ -1,5 +1,5 @@
 {-# OPTIONS_GHC -Wall #-}
-module Elm.Compiler.Version (version, rawVersion, elm) where
+module Elm.Compiler.Version (version, elm) where
 
 import qualified Data.Version as Version
 import qualified Paths_elm_compiler as This

--- a/src/Elm/Compiler/Version.hs
+++ b/src/Elm/Compiler/Version.hs
@@ -1,9 +1,9 @@
 {-# OPTIONS_GHC -Wall #-}
-module Elm.Compiler.Version (version, rawVersion) where
+module Elm.Compiler.Version (version, rawVersion, elm) where
 
 import qualified Data.Version as Version
 import qualified Paths_elm_compiler as This
-
+import Elm.Package
 
 version :: String
 version =
@@ -13,3 +13,18 @@ version =
 rawVersion :: [Int]
 rawVersion =
     Version.versionBranch This.version
+
+elm :: Version
+elm =
+  case rawVersion of
+    major : minor : patch : _ ->
+        Version major minor patch
+
+    [major, minor] ->
+        Version major minor 0
+
+    [major] ->
+        Version major 0 0
+
+    [] ->
+        error "could not detect version of elm-compiler you are using"

--- a/src/Elm/Docs.hs
+++ b/src/Elm/Docs.hs
@@ -14,6 +14,7 @@ import qualified Docs.AST as Docs
 import qualified Elm.Compiler.Module as Module
 import qualified Elm.Compiler.Type as Type
 import qualified Elm.Compiler.Version as Version
+import qualified Elm.Package as Pkg
 import qualified Reporting.Annotation as A
 
 
@@ -75,7 +76,7 @@ fromCheckedDocs name (Docs.Docs comment aliases unions values) =
     (map toAlias (Map.toList aliases))
     (map toUnion (Map.toList unions))
     (map toValue (Map.toList values))
-    (Version Version.version)
+    (Version $ (Pkg.versionToString Version.version))
 
 
 -- PRETTY JSON

--- a/src/Elm/Package.hs
+++ b/src/Elm/Package.hs
@@ -24,6 +24,11 @@ dummyName =
     Name "USER" "PROJECT"
 
 
+coreName :: Name
+coreName =
+  Name "elm-lang" "core"
+
+
 toString :: Name -> String
 toString name =
     user name ++ "/" ++ project name

--- a/src/Elm/Package.hs
+++ b/src/Elm/Package.hs
@@ -1,0 +1,182 @@
+{-# LANGUAGE FlexibleContexts #-}
+module Elm.Package where
+
+import Control.Applicative ((<$>), (<*>))
+import Control.Monad.Error.Class (MonadError, throwError)
+import Data.Aeson
+import Data.Binary
+import qualified Data.List as List
+import qualified Data.Text as T
+import qualified Data.Maybe as Maybe
+import System.FilePath ((</>))
+import Data.Char (isDigit)
+import Data.Function (on)
+
+data Name = Name
+    { user :: String
+    , project :: String
+    }
+    deriving (Eq, Ord)
+
+
+dummyName :: Name
+dummyName =
+    Name "USER" "PROJECT"
+
+
+toString :: Name -> String
+toString name =
+    user name ++ "/" ++ project name
+
+
+toUrl :: Name -> String
+toUrl name =
+    user name ++ "/" ++ project name
+
+
+toFilePath :: Name -> FilePath
+toFilePath name =
+    user name </> project name
+
+
+fromString :: String -> Maybe Name
+fromString string =
+    case break (=='/') string of
+      ( user@(_:_), '/' : project@(_:_) )
+          | all (/='/') project -> Just (Name user project)
+      _ -> Nothing
+
+
+fromString' :: (MonadError String m) => String -> m Name
+fromString' string =
+    Maybe.maybe (throwError $ errorMsg string) return (fromString string)
+
+
+instance Binary Name where
+    get = Name <$> get <*> get
+    put (Name user project) =
+        do  put user
+            put project
+
+
+instance FromJSON Name where
+    parseJSON (String text) =
+        let string = T.unpack text in
+        Maybe.maybe (fail $ errorMsg string) return (fromString string)
+
+    parseJSON _ = fail "Project name must be a string."
+
+
+instance ToJSON Name where
+    toJSON name =
+        toJSON (toString name)
+
+
+errorMsg :: String -> String
+errorMsg string =
+    unlines
+    [ "Dependency file has an invalid name: " ++ string
+    , "Must have format USER/PROJECT and match a public github project."
+    ]
+
+
+
+
+data Version = Version
+    { major :: Int
+    , minor :: Int
+    , patch :: Int
+    }
+    deriving (Eq, Ord)
+
+
+initialVersion :: Version
+initialVersion =
+    Version 1 0 0
+
+dummyVersion :: Version
+dummyVersion =
+    Version 0 0 0
+
+
+bumpPatch :: Version -> Version
+bumpPatch (Version major minor patch) =
+    Version major minor (patch + 1)
+
+bumpMinor :: Version -> Version
+bumpMinor (Version major minor _patch) =
+    Version major (minor + 1) 0
+
+bumpMajor :: Version -> Version
+bumpMajor (Version major _minor _patch) =
+    Version (major + 1) 0 0
+
+
+-- FILTERING
+
+filterLatest :: (Ord a) => (Version -> a) -> [Version] -> [Version]
+filterLatest characteristic versions =
+    map last (List.groupBy ((==) `on` characteristic) (List.sort versions))
+
+
+majorAndMinor :: Version -> (Int,Int)
+majorAndMinor (Version major minor _patch) =
+    (major, minor)
+
+
+-- CONVERSIONS
+
+versionToString :: Version -> String
+versionToString (Version major minor patch) =
+    show major ++ "." ++ show minor ++ "." ++ show patch
+
+
+versionFromString :: String -> Maybe Version
+versionFromString string =
+      case splitNumbers string of
+        Just [major, minor, patch] ->
+            Just (Version major minor patch)
+        _ -> Nothing
+    where
+      splitNumbers :: String -> Maybe [Int]
+      splitNumbers ns =
+          case span isDigit ns of
+            ("", _) ->
+                Nothing
+
+            (numbers, []) ->
+                Just [ read numbers ]
+
+            (numbers, '.':rest) ->
+                (read numbers :) <$> splitNumbers rest
+
+            _ -> Nothing
+
+
+instance Binary Version where
+    get = Version <$> get <*> get <*> get
+    put (Version major minor patch) =
+        do put major
+           put minor
+           put patch
+
+
+instance FromJSON Version where
+    parseJSON (String text) =
+        let string = T.unpack text in
+        case versionFromString string of
+          Just v -> return v
+          Nothing ->
+              fail $ unlines
+                 [ "Dependency file has an invalid version number: " ++ string
+                 , "Must have format MAJOR.MINOR.PATCH (e.g. 0.1.2)"
+                 ]
+
+    parseJSON _ =
+        fail "Version number must be stored as a string."
+
+
+instance ToJSON Version where
+    toJSON version =
+        toJSON (versionToString version)
+

--- a/src/Elm/Utils.hs
+++ b/src/Elm/Utils.hs
@@ -20,6 +20,7 @@ import System.Process (readProcessWithExitCode)
 import qualified AST.Expression.Source as Source
 import qualified AST.Pattern as Pattern
 import qualified Elm.Compiler.Version as Version
+import qualified Elm.Package as Pkg
 import qualified Parse.Helpers as Parse
 import qualified Parse.Expression as Parse
 import qualified Reporting.Annotation as A
@@ -127,8 +128,8 @@ errorNotFound name =
     , ""
     , "  * On Mac it is /usr/local/share/elm"
     , "  * On Windows it is one of the following:"
-    , "      C:/Program Files/Elm Platform/" ++ Version.version ++ "/share"
-    , "      C:/Program Files (x86)/Elm Platform/" ++ Version.version ++ "/share"
+    , "      C:/Program Files/Elm Platform/" ++ (Pkg.versionToString Version.version) ++ "/share"
+    , "      C:/Program Files (x86)/Elm Platform/" ++ (Pkg.versionToString Version.version) ++ "/share"
     , ""
     , "If you installed using npm, you have to set ELM_HOME to a certain directory"
     , "of the form .../node_modules/elm/share"

--- a/src/Elm/Utils.hs
+++ b/src/Elm/Utils.hs
@@ -19,7 +19,6 @@ import System.Process (readProcessWithExitCode)
 
 import qualified AST.Expression.Source as Source
 import qualified AST.Pattern as Pattern
-import qualified Elm.Package as Package
 import qualified Elm.Compiler.Version as Version
 import qualified Parse.Helpers as Parse
 import qualified Parse.Expression as Parse

--- a/src/Elm/Utils.hs
+++ b/src/Elm/Utils.hs
@@ -19,6 +19,7 @@ import System.Process (readProcessWithExitCode)
 
 import qualified AST.Expression.Source as Source
 import qualified AST.Pattern as Pattern
+import qualified Elm.Package as Package
 import qualified Elm.Compiler.Version as Version
 import qualified Parse.Helpers as Parse
 import qualified Parse.Expression as Parse

--- a/tests/Test/Compiler.hs
+++ b/tests/Test/Compiler.hs
@@ -12,7 +12,7 @@ import Test.Framework.Providers.HUnit (testCase)
 import Test.HUnit (Assertion, assertFailure, assertBool)
 
 import qualified Elm.Compiler as Compiler
-
+import qualified Elm.Package as Package
 
 compilerTests :: Test
 compilerTests =
@@ -54,7 +54,7 @@ testIf handleResult filePaths =
       source <- readFile filePath
 
       let context =
-            Compiler.Context "elm-lang" "core" True False
+            Compiler.Context (Package.Name "elm-lang" "core") True False
       let (dealiaser, _warnings, result) =
             Compiler.compile context source Map.empty
       let formatErrors errors =


### PR DESCRIPTION
SEE ALSO: related PRs for [elm-make](https://github.com/elm-lang/elm-make/pull/52) and [elm-package](https://github.com/elm-lang/elm-package/pull/127)

Refactors so that the `Name` type is in elm-compiler, so that we can pass Package names around the compiler process.

We create a new module, `Elm.Package`, containing the `Name` and `Version` types for packages.

`toString :: Version -> String` was renamed `verstionToString`, to avoid conflicts with `toString :: Name -> String`. Similarly with `fromString`.

We've moved the `elm :: Version` from Elm.Package.Version to Elm.Compiler, and renamed it to `version :: Version`.