### PR TITLE
 Avoid conflicts when modules have the same name

### DIFF
--- a/bench/src/IfBench.elm
+++ b/bench/src/IfBench.elm
@@ -3,70 +3,116 @@ module IfBench where
 tailRecursiveIfFn : Int -> Float
 tailRecursiveIfFn i = 
   if 
-    | i < 0 ->
-      10.0
-    | i == 0 ->
-      20.0
-    | i > 0 && i < 10 ->
-      30.0
-    | otherwise ->
+    i < 0 ->
+  then
+    10.0
+  else if
+    i == 0 ->
+  then
+    20.0
+  else if
+    i > 0 && i < 10 ->
+  then
+    30.0
+  else
       tailRecursiveIfFn (i - (1 + (i % 5 ) ) )
     
     
 manyConditionFunction i =
   if
-    | i <= 0 ->
-      30.0 + (toFloat i)
-    | i > 100 && (i * i) % 20 == 7 ->
-      24.3 + (toFloat i)
-    | i > 100 && (i % 3 == 1) ->
-      3.33 + (toFloat i)
-    | (i == 152) ->
-      29.0 + (toFloat i)
-    | (i + (i*i) > 200 && (i + (i*i) < 300)) -> 
+    i <= 0 
+  then
+    30.0 + (toFloat i)
+  else if
+    i > 100 && (i * i) % 20 == 7 
+  then
+    24.3 + (toFloat i)
+  else if
+    i > 100 && (i % 3 == 1) 
+  then
+    3.33 + (toFloat i)
+  else if
+    (i == 152) 
+  then
+    29.0 + (toFloat i)
+  else if
+    (i + (i*i) > 200 && (i + (i*i) < 300)) -> 
       32.9 + (toFloat i)
-    | i == 99 ->
-      93.0 + (toFloat i)
-    | (i*i % 17 == 13 ) ->
-      9.0 + (toFloat i)
-    | (i == 101) ->
-      39.0 + (toFloat i)
-    | (i == 102) ->
-      38.0 + (toFloat i)
-    | (i == 103) ->
-      49.0 + (toFloat i)
-    | (i == 104) ->
-      59.0 + (toFloat i)
-    | (i == 105) ->
-      69.0 + (toFloat i)
-    | (i == 106) ->
-      39.0 + (toFloat i)
-    | (i == 107) ->
-      38.0 + (toFloat i)
-    | (i == 108) ->
-      49.0 + (toFloat i)
-    | (i == 109) ->
-      59.0 + (toFloat i)
-    | (i == 110) ->
-      69.0 + (toFloat i)
-    | (i == 111) ->
-      39.0 + (toFloat i)
-    | (i == 115) ->
-      69.0 + (toFloat i)
-    | otherwise ->
-      toFloat i
+  else if
+    i == 99 
+  then
+    93.0 + (toFloat i)
+  else if
+    (i*i % 17 == 13 ) 
+  then
+    9.0 + (toFloat i)
+  else if
+    (i == 101) 
+  then
+    39.0 + (toFloat i)
+  else if
+    (i == 102) 
+  then
+    38.0 + (toFloat i)
+  else if
+    (i == 103) 
+  then
+    49.0 + (toFloat i)
+  else if
+    (i == 104) 
+  then
+    59.0 + (toFloat i)
+  else if
+    (i == 105) 
+  then
+    69.0 + (toFloat i)
+  else if
+    (i == 106) 
+  then
+    39.0 + (toFloat i)
+  else if
+    (i == 107) 
+  then
+    38.0 + (toFloat i)
+  else if
+    (i == 108) 
+  then
+    49.0 + (toFloat i)
+  else if
+    (i == 109) 
+  then
+    59.0 + (toFloat i)
+  else if
+    (i == 110) 
+  then
+    69.0 + (toFloat i)
+  else if
+    (i == 111) 
+  then
+    39.0 + (toFloat i)
+  else if
+    (i == 115) 
+  then
+    69.0 + (toFloat i)
+  else
+    toFloat i
       
       
 fewConditionFunction i =
   if
-    | i <= 0 ->
-      30.0 + (toFloat i)
-    | (i == 104) ->
-      59.0 + (toFloat i)
-    | (i == 105) ->
-      69.0 + (toFloat i)
-    | otherwise ->
-      toFloat i
+    i <= 0 
+  then
+    30.0 + (toFloat i)
+  else if
+    (i == 104) 
+  then
+    59.0 + (toFloat i)
+  else if
+    (i == 105) 
+  then
+    69.0 + (toFloat i)
+  else
+    toFloat i
   
   
 tailRecSum intList = 

--- a/src/AST/Module.hs
+++ b/src/AST/Module.hs
@@ -1,11 +1,12 @@
 module AST.Module
-    ( Interfaces
+    ( Interfaces, CanonicalInterfaces
     , Types, Aliases, ADTs
     , AdtInfo, CanonicalAdt
     , SourceModule, ValidModule, CanonicalModule, Optimized
     , Module(..), Body(..)
     , Header(..)
     , Name, nameToString, nameIsNative
+    , CanonicalName(..), canonPkg, canonModul
     , Interface(..), toInterface
     , UserImport, DefaultImport, ImportMethod(..)
     ) where
@@ -29,6 +30,7 @@ import qualified Reporting.Annotation as A
 -- HELPFUL TYPE ALIASES
 
 type Interfaces = Map.Map Name Interface
+type CanonicalInterfaces = Map.Map CanonicalName Interface
 
 type Types   = Map.Map String Type.Canonical
 type Aliases = Map.Map String ([String], Type.Canonical)
@@ -96,6 +98,13 @@ data Header imports = Header
 
 
 type Name = [String] -- must be non-empty
+
+
+data CanonicalName =
+  CanonicalName
+  { canonPkg :: Package.Name
+  , canonModul :: Name
+  }
 
 
 nameToString :: Name -> String

--- a/src/AST/Module.hs
+++ b/src/AST/Module.hs
@@ -145,11 +145,12 @@ data Interface = Interface
     , iAliases  :: Aliases
     , iFixities :: [(Decl.Assoc, Int, String)]
     , iPorts    :: [String]
+    , iPackage  :: Package.Name 
     }
 
 
-toInterface :: CanonicalModule -> Interface
-toInterface modul =
+toInterface :: Package.Name -> CanonicalModule -> Interface
+toInterface pkgName modul =
     let body' = body modul in
     Interface
     { iVersion  = Package.versionToString Compiler.version
@@ -160,11 +161,12 @@ toInterface modul =
     , iAliases  = aliases body'
     , iFixities = fixities body'
     , iPorts    = ports body'
+    , iPackage  = pkgName
     }
 
 
 instance Binary Interface where
-  get = Interface <$> get <*> get <*> get <*> get <*> get <*> get <*> get <*> get
+  get = Interface <$> get <*> get <*> get <*> get <*> get <*> get <*> get <*> get <*> get
   put modul = do
       put (iVersion modul)
       put (iExports modul)
@@ -174,3 +176,4 @@ instance Binary Interface where
       put (iAliases modul)
       put (iFixities modul)
       put (iPorts modul)
+      put (iPackage modul)

--- a/src/Compile.hs
+++ b/src/Compile.hs
@@ -17,18 +17,22 @@ import qualified Type.Inference as TI
 
 
 compile
-    :: Package.Name
+    :: Map.Map Module.Name Package.Name
+    -> Package.Name
     -> Bool
-    -> Module.Interfaces
+    -> Module.CanonicalInterfaces
     -> String
     -> Result.Result Warning.Warning Error.Error Module.CanonicalModule
 
-compile packageName isRoot interfaces source =
+compile importedPackages packageName isRoot interfaces source =
   do
       -- determine if default imports should be added
       -- only elm-lang/core is exempt
       let needsDefaults =
             not (packageName == Package.coreName)
+
+      let normalInterfaces =
+            unCanonicalizeInterfaces importedPackages interfaces 
 
       -- Parse the source code
       validModule <-
@@ -37,7 +41,7 @@ compile packageName isRoot interfaces source =
 
       -- Canonicalize all variables, pinning down where they came from.
       canonicalModule <-
-          Canonicalize.module' interfaces validModule
+          Canonicalize.module' normalInterfaces  validModule
 
       -- Run type inference on the program.
       types <-
@@ -48,7 +52,7 @@ compile packageName isRoot interfaces source =
       Result.mapError Error.Type $
         Nitpick.topLevelTypes types (Module.body validModule)
 
-      Nitpick.patternMatches interfaces canonicalModule
+      Nitpick.patternMatches normalInterfaces canonicalModule
 
       -- Add the real list of types
       let body = (Module.body canonicalModule) { Module.types = types }
@@ -56,9 +60,26 @@ compile packageName isRoot interfaces source =
       return $ canonicalModule { Module.body = body }
 
 
-getOpTable :: Module.Interfaces -> Parse.OpTable
+getOpTable :: Module.CanonicalInterfaces -> Parse.OpTable
 getOpTable interfaces =
   Map.elems interfaces
     |> concatMap Module.iFixities
     |> map (\(assoc,lvl,op) -> (op,(lvl,assoc)))
     |> Map.fromList
+
+
+unCanonicalizeInterfaces
+  :: Map.Map Module.Name Package.Name
+  -> Module.CanonicalInterfaces
+  -> Module.Interfaces
+unCanonicalizeInterfaces packageInfo ifaces =
+  let
+    foldFun canonName iface mapSoFar =
+      case Map.lookup (Module.canonModul canonName) packageInfo of
+        Just pkg | pkg == (error "TODO iface pkg") ->
+          Map.insert (Module.canonModul canonName) iface mapSoFar
+
+        _ ->
+          mapSoFar
+  in
+   Map.foldrWithKey foldFun Map.empty ifaces 

--- a/src/Compile.hs
+++ b/src/Compile.hs
@@ -76,7 +76,7 @@ unCanonicalizeInterfaces packageInfo ifaces =
   let
     foldFun canonName iface mapSoFar =
       case Map.lookup (Module.canonModul canonName) packageInfo of
-        Just pkg | pkg == (error "TODO iface pkg") ->
+        Just pkg | pkg == Module.iPackage iface ->
           Map.insert (Module.canonModul canonName) iface mapSoFar
 
         _ ->

--- a/src/Elm/Compiler.hs
+++ b/src/Elm/Compiler.hs
@@ -81,7 +81,7 @@ compile context source interfaces =
       do  modul <- Compile.compile unwrappedPackages packageName isRoot unwrappedInterfaces source
           docs <- docsGen isExposed modul
 
-          let interface = Module.toInterface modul
+          let interface = Module.toInterface packageName modul
           let optModule = Optimize.optimize modul
           let javascript = JS.generate optModule
 

--- a/src/Elm/Compiler/Module.hs
+++ b/src/Elm/Compiler/Module.hs
@@ -1,6 +1,7 @@
 module Elm.Compiler.Module
     ( Interface, Name(Name), name
-    , CanonicalName(CanonicalName), canonicalName, canonPkg, canonModul, fromCanonicalName
+    , CanonicalName(CanonicalName), canonicalName, canonPkg, canonModul
+    , fromCanonicalName, canonFromPackage
     , nameToPath
     , nameToString, nameFromString
     , hyphenate, dehyphenate
@@ -37,16 +38,22 @@ newtype Name = Name [String]
 data CanonicalName =
   CanonicalName
   { canonPkg :: Package.Name
+  , canonVersion :: Package.Version
   , canonModul :: Name
-  }
+  } deriving (Eq, Ord)
+
+
+canonFromPackage :: Package.Package -> Name -> CanonicalName
+canonFromPackage (pk, vr) nm =
+  CanonicalName pk vr nm
 
 
 fromCanonicalName :: CanonicalName -> Module.CanonicalName
-fromCanonicalName (CanonicalName p (Name n)) =
+fromCanonicalName (CanonicalName p _ (Name n)) =
   Module.CanonicalName p n
 
 
-canonicalName :: Package.Name -> Name -> CanonicalName
+canonicalName :: Package.Name -> Package.Version -> Name -> CanonicalName
 canonicalName = CanonicalName
 
 

--- a/src/Elm/Compiler/Module.hs
+++ b/src/Elm/Compiler/Module.hs
@@ -1,5 +1,6 @@
 module Elm.Compiler.Module
-    ( Interface, Name(Name)
+    ( Interface, Name(Name), name
+    , CanonicalName(CanonicalName), canonicalName, canonPkg, canonModul, fromCanonicalName
     , nameToPath
     , nameToString, nameFromString
     , hyphenate, dehyphenate
@@ -22,6 +23,7 @@ import qualified AST.Module as Module
 import qualified Elm.Compiler.Imports as Imports
 import qualified Elm.Compiler.Type as Type
 import qualified Elm.Compiler.Type.Extract as Extract
+import qualified Elm.Package as Package
 
 
 -- EXPOSED TYPES
@@ -31,6 +33,25 @@ type Interface = Module.Interface
 
 newtype Name = Name [String]
     deriving (Eq, Ord)
+
+data CanonicalName =
+  CanonicalName
+  { canonPkg :: Package.Name
+  , canonModul :: Name
+  }
+
+
+fromCanonicalName :: CanonicalName -> Module.CanonicalName
+fromCanonicalName (CanonicalName p (Name n)) =
+  Module.CanonicalName p n
+
+
+canonicalName :: Package.Name -> Name -> CanonicalName
+canonicalName = CanonicalName
+
+
+name :: [String] -> Name
+name = Name
 
 
 defaultImports :: [Name]

--- a/src/Elm/Package.hs
+++ b/src/Elm/Package.hs
@@ -19,6 +19,9 @@ data Name = Name
     deriving (Eq, Ord)
 
 
+type Package = (Name, Version)
+
+
 dummyName :: Name
 dummyName =
     Name "USER" "PROJECT"

--- a/tests/Test/Compiler.hs
+++ b/tests/Test/Compiler.hs
@@ -54,7 +54,7 @@ testIf handleResult filePaths =
       source <- readFile filePath
 
       let context =
-            Compiler.Context (Package.Name "elm-lang" "core") True False
+            Compiler.Context Package.coreName True False Map.empty
       let (dealiaser, _warnings, result) =
             Compiler.compile context source Map.empty
       let formatErrors errors =


### PR DESCRIPTION
SEE ALSO: [PR in elm-make](https://github.com/elm-lang/elm-make/pull/53).

NOTE: this appears to build things well, but it's hard to test because Core is currently broken (multi-way ifs and record updates).

This makes the changes necessary so that, when two packages have hidden modules with the same name, problems don't arise.

The ModuleNames we receive from Elm-make are now qualified by package name, and version. We also receive a dictionary mapping module names to package names for each imported package, so we know which interface files to give `Canonicalize.module'`. This dictionary has been added to the `Elm.Compiler.Context` type.

In Elm.Compiler.Module, we've added the `CanonicalName` type, which qualifies module names by package name and version. A similar type is in AST.Module, which uses AST.Module.Name instead of Elm.Module.Name.

The `Package` tuple synonym has been added to Elm.Package, which represents complete package information (name and version).