### PR TITLE
Add Facts to Canonical.Def

### DIFF
--- a/src/AST/Expression/Canonical.hs
+++ b/src/AST/Expression/Canonical.hs
@@ -30,7 +30,7 @@ data Def
 
 data Facts =
   Facts
-    { freeVariables :: [Var.Canonical]
+    { freeVariables :: [Var.TopLevelVar]
     } deriving (Eq, Ord, Show)
 
 

--- a/src/AST/Expression/Canonical.hs
+++ b/src/AST/Expression/Canonical.hs
@@ -24,12 +24,22 @@ type Expr' =
 
 
 data Def
-    = Definition Pattern.CanonicalPattern Expr (Maybe (A.Located Type.Canonical))
+    = Definition Facts Pattern.CanonicalPattern Expr (Maybe (A.Located Type.Canonical))
     deriving (Show)
 
 
+data Facts =
+  Facts
+    { freeVariables :: [Var.Canonical]
+    } deriving (Eq, Ord, Show)
+
+
+dummyFacts :: Facts
+dummyFacts = Facts $ error "This should be set by Canonicalize.Sort" 
+               
+
 instance P.Pretty Def where
-  pretty dealiaser _ (Definition pattern expr maybeTipe) =
+  pretty dealiaser _ (Definition _ pattern expr maybeTipe) =
       P.vcat [ annotation, definition ]
     where
       definition =

--- a/src/AST/Expression/Optimized.hs
+++ b/src/AST/Expression/Optimized.hs
@@ -6,6 +6,7 @@ module AST.Expression.Optimized
     ) where
 
 import qualified AST.Expression.General as General
+import qualified AST.Expression.Canonical as Canonical
 import qualified AST.Pattern as Pattern
 import qualified AST.Type as Type
 import qualified AST.Variable as Var
@@ -26,10 +27,11 @@ data Def
 
 data Facts = Facts
     { tailRecursionDetails :: Maybe String
+    , freeVariables :: [Var.Canonical]
     }
     deriving (Show)
 
 
 dummyFacts :: Facts
 dummyFacts =
-    Facts Nothing
+    Facts Nothing []

--- a/src/AST/Expression/Optimized.hs
+++ b/src/AST/Expression/Optimized.hs
@@ -27,7 +27,7 @@ data Def
 
 data Facts = Facts
     { tailRecursionDetails :: Maybe String
-    , freeVariables :: [Var.Canonical]
+    , freeVariables :: [Var.TopLevelVar]
     }
     deriving (Show)
 

--- a/src/AST/Variable.hs
+++ b/src/AST/Variable.hs
@@ -17,6 +17,13 @@ newtype Raw = Raw String
     deriving (Eq, Ord, Show)
 
 
+data TopLevelVar =
+  TopLevelVar
+  { topVarModule :: [String]
+  , topVarName :: String
+  } deriving (Eq, Ord, Show)
+
+
 data Home
     = BuiltIn
     | Module [String]

--- a/src/AST/Variable.hs
+++ b/src/AST/Variable.hs
@@ -19,7 +19,7 @@ newtype Raw = Raw String
 
 data TopLevelVar =
   TopLevelVar
-  { topVarModule :: [String]
+  { topVarModule :: ModuleName.Canonical
   , topVarName :: String
   } deriving (Eq, Ord, Show)
 

--- a/src/Canonicalize.hs
+++ b/src/Canonicalize.hs
@@ -328,7 +328,7 @@ declaration env (A.A ann@(region,_) decl) =
     case decl of
       D.Definition (Valid.Definition pat expr typ) ->
           D.Definition <$> (
-              Canonical.Definition
+              Canonical.Definition Canonical.dummyFacts
                 <$> pattern env pat
                 <*> expression env expr
                 <*> T.traverse (regionType env) typ
@@ -431,7 +431,7 @@ expression env (A.A region validExpr) =
               foldr Env.addPattern env $ map (\(Valid.Definition p _ _) -> p) defs
 
           rename' (Valid.Definition p body mtipe) =
-              Canonical.Definition
+              Canonical.Definition Canonical.dummyFacts
                   <$> pattern env' p
                   <*> expression env' body
                   <*> T.traverse (regionType env') mtipe

--- a/src/Canonicalize/Declaration.hs
+++ b/src/Canonicalize/Declaration.hs
@@ -91,4 +91,7 @@ buildFunction body@(A.A ann _) vars =
 
 definition :: String -> Canonical.Expr -> R.Region -> T.Canonical -> Canonical.Def
 definition name expr@(A.A ann _) region tipe =
-  Canonical.Definition (A.A ann (P.Var name)) expr (Just (A.A region tipe))
+  let
+    facts = Canonical.Facts (error "Sort needs to fill in refgraph")
+  in
+    Canonical.Definition facts (A.A ann (P.Var name)) expr (Just (A.A region tipe))

--- a/src/Canonicalize/Declaration.hs
+++ b/src/Canonicalize/Declaration.hs
@@ -92,6 +92,6 @@ buildFunction body@(A.A ann _) vars =
 definition :: String -> Canonical.Expr -> R.Region -> T.Canonical -> Canonical.Def
 definition name expr@(A.A ann _) region tipe =
   let
-    facts = Canonical.Facts (error "Sort needs to fill in refgraph")
+    facts = Canonical.dummyFacts
   in
     Canonical.Definition facts (A.A ann (P.Var name)) expr (Just (A.A region tipe))

--- a/src/Canonicalize/Declaration.hs
+++ b/src/Canonicalize/Declaration.hs
@@ -91,7 +91,5 @@ buildFunction body@(A.A ann _) vars =
 
 definition :: String -> Canonical.Expr -> R.Region -> T.Canonical -> Canonical.Def
 definition name expr@(A.A ann _) region tipe =
-  let
-    facts = Canonical.dummyFacts
-  in
-    Canonical.Definition facts (A.A ann (P.Var name)) expr (Just (A.A region tipe))
+  Canonical.Definition Canonical.dummyFacts
+    (A.A ann (P.Var name)) expr (Just (A.A region tipe))

--- a/src/Canonicalize/Sort.hs
+++ b/src/Canonicalize/Sort.hs
@@ -123,7 +123,7 @@ reorder (A.A ann expression) =
               let defss = map Graph.flattenSCC sccs
 
               -- remove let-bound variables from the context
-              forM_ defs $ \(Canonical.Definition pattern _ _) -> do
+              forM_ defs $ \(Canonical.Definition _ pattern _ _) -> do
                   bound pattern
                   mapM free (ctors pattern)
 
@@ -193,7 +193,7 @@ buildDefGraph defs =
         zipWith (\n (pdef,deps) -> (pdef,n,deps)) [0..]
 
     variableToKey :: (Canonical.Def, Int, [String]) -> [(String, Int)]
-    variableToKey (Canonical.Definition pattern _ _, key, _) =
+    variableToKey (Canonical.Definition _ pattern _ _, key, _) =
         [ (var, key) | var <- P.boundVarList pattern ]
 
     variableToKeyMap :: [(Canonical.Def, Int, [String])] -> Map.Map String Int
@@ -212,7 +212,7 @@ buildDefGraph defs =
 reorderAndGetDependencies
     :: Canonical.Def
     -> State (Set.Set String) (Canonical.Def, [String])
-reorderAndGetDependencies (Canonical.Definition pattern expr mType) =
+reorderAndGetDependencies (Canonical.Definition facts pattern expr mType) =
   do  globalFrees <- get
       -- work in a fresh environment
       put Set.empty
@@ -220,4 +220,4 @@ reorderAndGetDependencies (Canonical.Definition pattern expr mType) =
       localFrees <- get
       -- merge with global frees
       modify (Set.union globalFrees)
-      return (Canonical.Definition pattern expr' mType, Set.toList localFrees)
+      return (Canonical.Definition facts pattern expr' mType, Set.toList localFrees)

--- a/src/Docs/Centralize.hs
+++ b/src/Docs/Centralize.hs
@@ -54,7 +54,7 @@ toRawDocs decls =
 addDeclToDocs :: D.CanonicalDecl -> Raw -> Raw
 addDeclToDocs (A.A (region,maybeComment) decl) docs =
   case decl of
-    D.Definition (Canonical.Definition (A.A subregion (P.Var name)) _ maybeType) ->
+    D.Definition (Canonical.Definition _ (A.A subregion (P.Var name)) _ maybeType) ->
         let
           info =
             ( maybeComment

--- a/src/Nitpick/PatternMatches.hs
+++ b/src/Nitpick/PatternMatches.hs
@@ -144,7 +144,7 @@ checkExpression tagDict (A.A region expression) =
         go body
           <* F.traverse_ goDef defs
       where
-        goDef (Canonical.Definition pattern expr _) =
+        goDef (Canonical.Definition _ pattern expr _) =
             goPattern [pattern]
             <* go expr
 

--- a/src/Optimize/TailCalls.hs
+++ b/src/Optimize/TailCalls.hs
@@ -51,7 +51,7 @@ mapSnd func (x, a) =
 -- CONVERT DEFINITIONS
 
 detectTailRecursion :: Can.Def -> Opt.Def
-detectTailRecursion (Can.Definition pattern expression _) =
+detectTailRecursion (Can.Definition _ pattern expression _) =
     let
         (args, body) =
             Expr.collectLambdas expression

--- a/src/Optimize/TailCalls.hs
+++ b/src/Optimize/TailCalls.hs
@@ -51,7 +51,7 @@ mapSnd func (x, a) =
 -- CONVERT DEFINITIONS
 
 detectTailRecursion :: Can.Def -> Opt.Def
-detectTailRecursion (Can.Definition _ pattern expression _) =
+detectTailRecursion (Can.Definition canonFacts pattern expression _) =
     let
         (args, body) =
             Expr.collectLambdas expression
@@ -71,9 +71,14 @@ detectTailRecursion (Can.Definition _ pattern expression _) =
 
         lambda x e =
             A.A () (Lambda x e)
+
+        facts =
+          Opt.Facts
+            (if isTailCall then fmap fst context else Nothing)
+            (Can.freeVariables canonFacts)
     in
         Opt.Definition
-          (Opt.Facts (if isTailCall then fmap fst context else Nothing))
+          facts
           (removeAnnotations pattern)
           (foldr lambda optExpr (map removeAnnotations args))
 

--- a/src/Type/Constrain/Expression.hs
+++ b/src/Type/Constrain/Expression.hs
@@ -451,7 +451,7 @@ collectPairs index items =
 -- EXPAND PATTERNS
 
 expandPattern :: Canonical.Def -> [Canonical.Def]
-expandPattern def@(Canonical.Definition lpattern expr maybeType) =
+expandPattern def@(Canonical.Definition facts lpattern expr maybeType) =
   let (A.A patternRegion pattern) = lpattern
   in
   case pattern of
@@ -471,13 +471,13 @@ expandPattern def@(Canonical.Definition lpattern expr maybeType) =
         localVar name =
             A.A patternRegion (E.localVar name)
 
-        mainDef = Canonical.Definition (pvar combinedName) expr maybeType
+        mainDef = Canonical.Definition facts (pvar combinedName) expr maybeType
 
         toDef name =
             let extract =
                   E.Case (localVar combinedName) [(lpattern, localVar name)]
             in
-                Canonical.Definition (pvar name) (A.A patternRegion extract) Nothing
+                Canonical.Definition facts (pvar name) (A.A patternRegion extract) Nothing
 
 
 -- CONSTRAIN DEFINITIONS
@@ -493,7 +493,7 @@ data Info = Info
 
 
 constrainDef :: Env.Environment -> Info -> Canonical.Def -> IO Info
-constrainDef env info (Canonical.Definition (A.A patternRegion pattern) expr maybeTipe) =
+constrainDef env info (Canonical.Definition _ (A.A patternRegion pattern) expr maybeTipe) =
   let qs = [] -- should come from the def, but I'm not sure what would live there...
   in
   case (pattern, maybeTipe) of


### PR DESCRIPTION
Adds annotations containing the referenced top-levels and imported variables for each Definition in a module.