### PR TITLE
Remove unused package dependencies

### DIFF
--- a/elm-compiler.cabal
+++ b/elm-compiler.cabal
@@ -131,10 +131,7 @@ Library
         ansi-terminal >= 0.6.2.1 && < 0.7,
         base >=4.2 && <5,
         binary >= 0.7.0.0 && < 0.8,
-        blaze-html >= 0.5 && < 0.9,
-        blaze-markup >= 0.5.1 && < 0.8,
         bytestring >= 0.9 && < 0.11,
-        cmdargs >= 0.7 && < 0.11,
         containers >= 0.3 && < 0.6,
         directory >= 1.0 && < 2.0,
         edit-distance >= 0.2 && < 0.3,
@@ -147,9 +144,7 @@ Library
         pretty >= 1.0 && < 2.0,
         process,
         text >= 1 && < 2,
-        transformers >= 0.2 && < 0.5,
         union-find >= 0.2 && < 0.3,
-        unordered-containers >= 0.1 && < 0.3,
         wl-pprint
 
 
@@ -173,7 +168,6 @@ Executable elm
         binary >= 0.7.0.0 && < 0.8,
         directory >= 1.0 && < 2.0,
         filepath >= 1 && < 2.0,
-        mtl >= 2.2 && < 3,
         text >= 1 && < 2,
         elm-compiler,
         process
@@ -208,10 +202,7 @@ Test-Suite compiler-tests
         ansi-terminal >= 0.6.2.1 && < 0.7,
         base >=4.2 && <5,
         binary >= 0.7.0.0 && < 0.8,
-        blaze-html >= 0.5 && < 0.9,
-        blaze-markup >= 0.5.1 && < 0.8,
         bytestring >= 0.9 && < 0.11,
-        cmdargs >= 0.7 && < 0.11,
         containers >= 0.3 && < 0.6,
         directory >= 1.0 && < 2.0,
         edit-distance >= 0.2 && < 0.3,
@@ -226,6 +217,5 @@ Test-Suite compiler-tests
         pretty >= 1.0 && < 2.0,
         process,
         text >= 1 && < 2,
-        transformers >= 0.2 && < 0.5,
         union-find >= 0.2 && < 0.3,
         wl-pprint

--- a/elm-compiler.cabal
+++ b/elm-compiler.cabal
@@ -169,7 +169,6 @@ Executable elm
         directory >= 1.0 && < 2.0,
         filepath >= 1 && < 2.0,
         text >= 1 && < 2,
-        elm-compiler,
         process
 
 


### PR DESCRIPTION
Remove unused package dependencies from `elm-compiler.cabal`. These were detected using HVR's [`packunused`](https://hackage.haskell.org/package/packunused) utility. This should hopefully reduce build times and slightly reduce incidences of "Cabal hell" in the future.

This PR also removes the elm-compiler dependency from the elm executable as the bug in stack requiring this change has been fixed and a new version of stack released. I kept it in a separate commit in case you want to cherry pick.