### PR TITLE
Test fix empty expected files

### DIFF
--- a/tests/Test/Compiler.hs
+++ b/tests/Test/Compiler.hs
@@ -121,6 +121,9 @@ doWriteNewExpectedTest expectedJsDir filePath =
             case formattedResult of
                 Right (Compiler.Result _ _ js) ->
                   do  createDirectoryIfMissing True (dropFileName expectedFilePath)
+                      -- Force the evaluation of "js" before "writeFile"
+                      --  so that if an error is raised we do not write an empty file.
+                      assertBool "Error: no content generated" (length js > 0)
                       writeFile expectedFilePath js
                       assertFailure ("Wrote new expected js: " ++ expectedFilePath)
 


### PR DESCRIPTION
Right now Generate/JavaScript.hs has a lot of errors. So if you run:
`ELM_WRITE_NEW_EXPECTED=1 cabal test`
It will write empty files for all the examples with errors.

But there are several other test cases which do compile and do need to be updated, and you don't want to have to pick through which ones to commit.
@evancz 