### PR TITLE
Enable caching of ~/.cabal on Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 sudo: false
 
+cache:
+  directories:
+  - $HOME/.cabal
+
 addons:
   apt:
     sources:


### PR DESCRIPTION
Enable caching of ~/.cabal on Travis-CI

Depends on #1053 