### PR TITLE
Add MultiParamTypeClasses pragma where appropriate

### DIFF
--- a/src/Elm/Utils.hs
+++ b/src/Elm/Utils.hs
@@ -1,5 +1,6 @@
 {-# OPTIONS_GHC -Wall #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
 module Elm.Utils
     ( (|>), (<|)
     , getAsset

--- a/src/Type/State.hs
+++ b/src/Type/State.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
 module Type.State where
 
 import Control.Applicative ( Applicative, (<$>), (<*>), (<|>) )


### PR DESCRIPTION
This allows the elm-compiler source code to be properly parsed by haskell-src-exts.  (This allows, for instance, elm-compiler to be processed by [SourceGraph](https://hackage.haskell.org/package/SourceGraph))

For background: GHC has a bug that allows successful compilation without the MultiParamTypeClasses pragma, but such files are "not valid standard haskell".  See https://github.com/haskell-suite/haskell-src-exts/issues/29