### PR TITLE
Expected output tests for Debug.crash.

### DIFF
--- a/tests/test-files/good-expected-js/Crash/CrashCase.elm.js
+++ b/tests/test-files/good-expected-js/Crash/CrashCase.elm.js
@@ -1,0 +1,20 @@
+Elm.Main = Elm.Main || {};
+Elm.Main.make = function (_elm) {
+   "use strict";
+   _elm.Main = _elm.Main || {};
+   if (_elm.Main.values) return _elm.Main.values;
+   var _U = Elm.Native.Utils.make(_elm),
+   $Debug = Elm.Debug.make(_elm);
+   var _op = {};
+   var test = function (x) {
+      var _p0 = x;
+      if (_p0 === 1) {
+            return 2;
+         } else {
+            return _U.crashCase("Main",
+            {start: {line: 5,column: 5},end: {line: 9,column: 43}},
+            _p0)("unexpected value");
+         }
+   };
+   return _elm.Main.values = {_op: _op,test: test};
+};

--- a/tests/test-files/good-expected-js/Crash/CrashIf.elm.js
+++ b/tests/test-files/good-expected-js/Crash/CrashIf.elm.js
@@ -1,0 +1,15 @@
+Elm.Main = Elm.Main || {};
+Elm.Main.make = function (_elm) {
+   "use strict";
+   _elm.Main = _elm.Main || {};
+   if (_elm.Main.values) return _elm.Main.values;
+   var _U = Elm.Native.Utils.make(_elm),
+   $Debug = Elm.Debug.make(_elm);
+   var _op = {};
+   var test = function (x) {
+      return x ? 2 : _U.crash("Main",
+      {start: {line: 8,column: 9}
+      ,end: {line: 8,column: 20}})("unexpected value");
+   };
+   return _elm.Main.values = {_op: _op,test: test};
+};

--- a/tests/test-files/good/Crash/CrashCase.elm
+++ b/tests/test-files/good/Crash/CrashCase.elm
@@ -1,0 +1,9 @@
+
+import Debug
+
+test x =
+    case x of
+        1 ->
+            2
+        _ ->
+            Debug.crash "unexpected value"

--- a/tests/test-files/good/Crash/CrashIf.elm
+++ b/tests/test-files/good/Crash/CrashIf.elm
@@ -1,0 +1,8 @@
+
+import Debug
+
+test x =
+    if x then
+        2
+    else
+        Debug.crash "unexpected value"


### PR DESCRIPTION
 * Expose `Debug.crash : String -> a` in test-files compilation.
 * Add expected output for `Utils.crash` and `Utils.crashCase`