### PR TITLE
Merge in online hints for annotations and recursive aliases

### DIFF
--- a/hints/recursive-alias.md
+++ b/hints/recursive-alias.md
@@ -1,0 +1,161 @@
+# Hints for Recursive Type Aliases
+
+At the root of this issue is the distinction between a `type` and a `type alias`.
+
+
+## What is a type alias?
+
+When you create a type alias, you are just creating a shorthand to refer to an existing type. So when you say the following:
+
+```elm
+type alias Time = Float
+
+type alias Degree = Float
+
+type alias Weight = Float
+```
+
+You have not created any *new* types, you just made some alternate names for `Float`. You can write down things like this and it'll work fine:
+
+```elm
+add : Time -> Degree -> Weight
+add time degree =
+  time + degree
+```
+
+This is kind of a weird way to use type aliases though. The typical usage would be for records, where you do not want to write out the whole thing every time. Stuff like this:
+
+```elm
+type alias Person =
+  { name : String
+  , age : Int
+  , height : Float
+  }
+```
+
+It is much easier to write down `Person` in a type, and then it will just expand out to the underlying type when the compiler checks the program.
+
+
+## Recursive type aliases?
+
+Okay, so lets say you have some type that may contain itself. In Elm, a common example of this is a comment that might have subcomments:
+
+```elm
+type alias Comment =
+  { message : String
+  , upvotes : Int
+  , downvotes : Int
+  , responses : List Comment
+  }
+```
+
+Now remember that type *aliases* are just alternate names for the real type. So to make `Comment` into a concrete type, the compiler would start expanding it out.
+
+```elm
+  { message : String
+  , upvotes : Int
+  , downvotes : Int
+  , responses :
+      List
+        { message : String
+        , upvotes : Int
+        , downvotes : Int
+        , responses :
+            List
+              { message : String
+              , upvotes : Int
+              , downvotes : Int
+              , responses : List ...
+              }
+        }
+  }
+```
+
+The compiler cannot deal with values like this. It would just keep expanding forever.
+
+
+## Recursive types!
+
+In cases where you want a recursive type, you need to actually create a brand new type. This is what the `type` keyword is for. A simple example of this can be seen when defining a linked list:
+
+```elm
+type List
+    = Empty
+    | Node Int List
+```
+
+No matter what, the type of `Node n xs` is going to be `List`. There is no expansion to be done. This means you can represent recursive structures with types do not explode into infinity.
+
+So let's return to wanting to represent a `Comment` that may have responses. There are a couple ways to do this:
+
+
+### Obvious, but kind of annoying 
+
+```elm
+type Comment =
+   Comment
+      { message : String
+      , upvotes : Int
+      , downvotes : Int
+      , responses : List Comment
+      }
+```
+
+Now lets say you want to register an upvote on a comment:
+
+```elm
+upvote : Comment -> Comment
+upvote (Comment comment) =
+  Comment { comment | upvotes = 1 + comment.upvotes }
+```
+
+It is kind of annoying that we now have to unwrap and wrap the record to do anything with it.
+
+
+### Less obvious, but nicer
+
+```elm
+type alias Comment =
+  { message : String
+  , upvotes : Int
+  , downvotes : Int
+  , responses : Responses
+  }
+
+type Responses = Responses (List Comment)
+```
+
+In this world, we introduce the `Responses` type to capture the recursion, but `Comment` is still an alias for a record. This means the `upvote` function looks nice again:
+
+```elm
+upvote : Comment -> Comment
+upvote comment =
+  { comment | upvotes = 1 + comment.upvotes }
+```
+
+So rather than having to unwrap a `Comment` to do *anything* to it, you only have to do some unwrapping in the cases where you are doing something recusive. In practice, this means you will do less unwrapping which is nice.
+
+
+## Mutually recursive type aliases
+
+It is also possible to build type aliases that are *mutually* recursive. That might be something like this:
+
+```elm
+type alias Comment =
+  { message : String
+  , upvotes : Int
+  , downvotes : Int
+  , responses : Responses
+  }
+
+type alias Responses =
+  { sortBy : SortBy
+  , responses : List Comment
+  }
+
+type SortBy = Time | Score | MostResponses
+```
+
+When you try to expand `Comment` you have to expand `Responses` which needs to expand `Comment` which needs to expand `Responses`, etc.
+
+So this is just a fancy case of a self-recusive type alias. The solution is the same. Somewhere in that cycle, you need to define an actual `type` to end the infinite expansion.

--- a/hints/type-annotations.md
+++ b/hints/type-annotations.md
@@ -1,0 +1,66 @@
+# Hints for Type Annotation Problems
+
+At the root of this kind of issue is always the fact that a type annotation in your code does not match the corresponding definition. Now that may mean that the type annotation is "wrong" or it may mean that the definition is "wrong". The compiler cannot figure out your intent, only that there is some mismatch.
+
+This document is going to outline the various things that can go wrong and show some examples.
+
+
+## Annotation vs. Definition
+
+The most common issue is with user-defined type variables that are too general. So lets say you have defined a function like this:
+
+```elm
+addPair : (a, a) -> a
+addPair (x, y) =
+  x + y
+```
+
+The issue is that the type annotation is saying "I will accept a tuple containing literally *anything*" but the definition is using `(+)` which requires things to be numbers. So the compiler is going to infer that the true type of the definition is this:
+
+```elm
+addPair : (number, number) -> number
+```
+
+So you will probably see an error saying "I cannot match `a` with `number`" which is essentially saying, you are trying to provide a type annotation that is **too general**. You are saying `addPair` accepts anything, but in fact, it can only handle numbers.
+
+In cases like this, you want to go with whatever the compiler inferred. It is good at figuring this kind of stuff out ;)
+
+
+## Annotation vs. Itself
+
+It is also possible to have a type annotation that clashes with itself. This is probably more rare, but someone will run into it eventually. Let's use another version of `addPair` with problems:
+
+```elm
+addPair : (Int, Int) -> number
+addPair (x, y) =
+  x + y
+```
+
+In this case the annotation says we should get a `number` out, but because we were specific about the inputs being `Int`, the output should also be an `Int`.
+
+
+## Annotation vs. Internal Annotation
+
+A quite tricky case is when an outer type annotation clashes with an inner type annotation. Here is an example of this:
+
+```elm
+filter : (a -> Bool) -> List a -> List a
+filter isOkay list =
+  let
+    keepIfOkay : a -> Maybe a
+    keepIfOkay x =
+      if isOkay x then Just x else Nothing
+  in
+    List.filterMap keepIfOkay list
+```
+
+This case is very unfortunate because all the type annotations are correct, but there is a detail of how type inference works right now that **user-defined type variables are not shared between annotations**. This can lead to probably the worst type error messages we have because the problem here is that `a` in the outer annotation does not equal `a` in the inner annotation.
+
+For now the best route is to leave off the inner annotation. It is unfortunate, and hopefully we will be able to do a nicer thing in future releases.
+
+
+
+
+
+
+

--- a/src/Reporting/Error/Canonicalize.hs
+++ b/src/Reporting/Error/Canonicalize.hs
@@ -182,8 +182,9 @@ toReport localizer err =
                     , indent 4 $
                         RenderType.decl localizer name tvars [(name, [unsafePromote tipe])]
                     , text $
-                        "This creates a brand new type that cannot be expanded. Read more about this at:\n"
-                        ++ Help.hintLink "infinite-alias"
+                        "This is kind of a subtle distinction. I suggested the naive fix, but you can\n"
+                        ++ "often do something a bit nicer. So I would recommend reading more at:\n"
+                        ++ Help.hintLink "recursive-alias"
                     ]
                 )
 
@@ -194,11 +195,11 @@ toReport localizer err =
                 "This type alias is part of a mutually recursive set of type aliases."
                 ( Help.stack
                     [ text "The following type aliases are mutually recursive:"
-                    , Help.drawCycle (map (\(_, name, _, _) -> name) aliases)
+                    , indent 4 (Help.drawCycle (map (\(_, name, _, _) -> name) aliases))
                     , Help.reflowParagraph $
                         "You need to convert at least one `type alias` into a `type`. This is a kind of\
-                        \ subtle distinction, so definitely read how to fix it and have great code:"
-                        ++ Help.hintLink "infinite-alias"
+                        \ subtle distinction, so definitely read up on this before you make a fix: "
+                        ++ Help.hintLink "recursive-alias"
                     ]
                 )
 

--- a/src/Reporting/Error/Type.hs
+++ b/src/Reporting/Error/Type.hs
@@ -508,41 +508,30 @@ reasonToString reason =
         go "Only strings and lists are both comparable and appendable."
 
     BadVar (Just (Rigid _)) (Just (Rigid _)) ->
-        Just $ Help.stack $
-          [ hintDoc <> text "This usually happens when a few factors come together."
-          , indent 4 $ vcat $
-              [ text "1. You have a generic function with a type annotation."
-              , text "2. In its definition, there is a `let` with generic type annotations."
-              ]
-          , Help.reflowParagraph
-              "The issue is that these type variables are not actually shared between\
-              \ outer and inner type annotations right now. You can usually fix this by\
-              \ commenting out the inner type annotations."
-          ]
-
-    BadVar (Just (Rigid (Just name))) _ ->
-        go $
-          "Looks like the type annotation is too generic. Type variable\
-          \ `" ++ name ++ "` is saying *many* kinds of value can be given, but the\
-          \ actual definition needs a more specific type. I am not sure whether the\
-          \ type annotation or the definition is \"right\" though, you may have to\
-          \ make the annotation more specific or make the definition more generic."
+        go doubleRigidError
 
     BadVar (Just (Rigid _)) _  ->
-        go genericRigidError
+        go singleRigidError
 
     BadVar _ (Just (Rigid _))  ->
-        go genericRigidError
+        go singleRigidError
 
     BadVar _ _ ->
         Nothing
 
 
-genericRigidError :: String
-genericRigidError =
-  "There is some problem with a rigid type variable. It is very likely that a\
-  \ type annotation is too generic. One type is saying *many* kinds of value\
-  \ can be given, but the other needs a more specific type."
+singleRigidError :: String
+singleRigidError =
+  "A type annotation is too generic. You can probably just switch to the\
+  \ type I inferred. These issues can be subtle though, so read more about it. "
+  ++ Help.hintLink "type-annotations"
+
+
+doubleRigidError :: String
+doubleRigidError =
+  "A type annotation is clashing with itself or with a sub-annotation.\
+  \ This can be particularly tricky, so read more about it. "
+  ++ Help.hintLink "type-annotations"
 
 
 hintDoc :: Doc

--- a/src/Type/Constrain/Expression.hs
+++ b/src/Type/Constrain/Expression.hs
@@ -89,7 +89,7 @@ constrain env annotatedExpr@(A.A region expression) tipe =
                             (CLet [monoscheme (Fragment.typeEnv fragment)]
                                   (Fragment.typeConstraint fragment /\ bodyCon)
                             )
-                  return $ con /\ CEqual Error.Lambda region tipe (argType ==> resType)
+                  return $ con /\ CEqual Error.Lambda region (argType ==> resType) tipe
 
       E.App _ _ ->
           let
@@ -125,7 +125,7 @@ constrain env annotatedExpr@(A.A region expression) tipe =
 
                   newVars <- mapM (\_ -> mkVar Nothing) fields
                   let newFields = Map.fromList (zip (map fst fields) (map VarN newVars))
-                  let cNew = CEqual Error.Record region tipe (record newFields t)
+                  let cNew = CEqual Error.Record region (record newFields t) tipe
 
                   cs <- Monad.zipWithM (constrain env) (map snd fields) (map VarN newVars)
 
@@ -140,7 +140,7 @@ constrain env annotatedExpr@(A.A region expression) tipe =
                       (map VarN vars)
               let fields' = Map.fromList (zip (map fst fields) (map VarN vars))
               let recordType = record fields' (TermN EmptyRecord1)
-              return (ex vars (CAnd (fieldCons ++ [CEqual Error.Record region tipe recordType])))
+              return (ex vars (CAnd (fieldCons ++ [CEqual Error.Record region recordType tipe])))
 
       E.Let defs body ->
           do  bodyCon <- constrain env body tipe
@@ -281,7 +281,7 @@ constrainBinop env region op leftExpr@(A.A leftRegion _) rightExpr@(A.A rightReg
           , CInstance region (V.toString op) opType
           , CEqual (Error.BinopLeft op leftRegion) region (VarN leftVar') (VarN leftVar)
           , CEqual (Error.BinopRight op rightRegion) region (VarN rightVar') (VarN rightVar)
-          , CEqual (Error.Binop op) region tipe (VarN answerVar)
+          , CEqual (Error.Binop op) region (VarN answerVar) tipe
           ]
 
 
@@ -307,7 +307,7 @@ constrainList env region exprs tipe =
           return ( (var, region'), con )
 
     varToCon var =
-      CEqual Error.List region tipe (Env.getType env "List" <| VarN var)
+      CEqual Error.List region (Env.getType env "List" <| VarN var) tipe
 
 
 -- CONSTRAIN IF EXPRESSIONS


### PR DESCRIPTION
Always call things “user-defined type variables” instead of “rigid type
variables”

Try to be more non-specific in the case of a rigid/rigid clash, just
link out to hint documentation.