### PR TITLE
Specific annotations tests

### DIFF
--- a/tests/test-files/good-expected-js/Soundness/SpecificAnnotationInt.elm.js
+++ b/tests/test-files/good-expected-js/Soundness/SpecificAnnotationInt.elm.js
@@ -1,0 +1,10 @@
+Elm.Main = Elm.Main || {};
+Elm.Main.make = function (_elm) {
+   "use strict";
+   _elm.Main = _elm.Main || {};
+   if (_elm.Main.values) return _elm.Main.values;
+   var _U = Elm.Native.Utils.make(_elm);
+   var _op = {};
+   var px = function (x) {    return "test";};
+   return _elm.Main.values = {_op: _op,px: px};
+};

--- a/tests/test-files/good-expected-js/Soundness/SpecificAnnotationNumber.elm.js
+++ b/tests/test-files/good-expected-js/Soundness/SpecificAnnotationNumber.elm.js
@@ -1,0 +1,10 @@
+Elm.Main = Elm.Main || {};
+Elm.Main.make = function (_elm) {
+   "use strict";
+   _elm.Main = _elm.Main || {};
+   if (_elm.Main.values) return _elm.Main.values;
+   var _U = Elm.Native.Utils.make(_elm);
+   var _op = {};
+   var px = function (x) {    return "test";};
+   return _elm.Main.values = {_op: _op,px: px};
+};

--- a/tests/test-files/good/Soundness/SpecificAnnotationInt.elm
+++ b/tests/test-files/good/Soundness/SpecificAnnotationInt.elm
@@ -1,0 +1,2 @@
+px : Int -> String
+px x = "test"

--- a/tests/test-files/good/Soundness/SpecificAnnotationNumber.elm
+++ b/tests/test-files/good/Soundness/SpecificAnnotationNumber.elm
@@ -1,0 +1,2 @@
+px : number -> String
+px x = "test"


### PR DESCRIPTION
Add (failing) tests for #1143.

In general, it should be possible to restrict a type by writing an annotation more specific than the inferred type. One test catches a 0.16-alpha regression in which doing so for `number` (also `comparable`, `appendable`) was disallowed. The other test verifies that doing so for concrete type `Int` works, which it always has, but it seemed like a good thing to test, and it allowed me to write the expected JS (which is identical for both tests).