### PR TITLE
Test invalid type aliases

### DIFF
--- a/tests/test-files/bad/MissingTypeVariables.elm
+++ b/tests/test-files/bad/MissingTypeVariables.elm
@@ -1,0 +1,1 @@
+type alias Bad = List

--- a/tests/test-files/bad/PhantomTypeAliases.elm
+++ b/tests/test-files/bad/PhantomTypeAliases.elm
@@ -1,0 +1,2 @@
+type MyData = MyData String
+type alias MyDataAlias a = MyData


### PR DESCRIPTION
This is a separate PR to add more failing tests for other issues, related to type aliases.

PhantomTypeAliases is a regression test for #1110. It passes in master.

MissingTypeVariables is a currently failing test for #1146. I have bundled them together to show that fixing one has not fixed the other.