### PR TITLE
Allow Char values to be passed through ports

### DIFF
--- a/src/AST/Variable.hs
+++ b/src/AST/Variable.hs
@@ -140,7 +140,7 @@ isPrimitive :: Canonical -> Bool
 isPrimitive v =
     case v of
       Canonical BuiltIn name ->
-          name `elem` ["Int","Float","String","Bool"]
+          name `elem` ["Int","Float","String","Char","Bool"]
       _ ->
           False
 

--- a/src/Generate/JavaScript/Port.hs
+++ b/src/Generate/JavaScript/Port.hs
@@ -134,6 +134,9 @@ toType tipe x =
           where
             from checks = check x checks x
 
+      T.Type (Var.Canonical Var.BuiltIn "Char") ->
+            check x JSString (obj ["_U","chr"] `call` [x])
+
       T.Type name
           | Var.isJson name ->
               x
@@ -237,7 +240,7 @@ fromType tipe x =
           error "type variables should not be allowed through outputs"
 
       T.Type (Var.Canonical Var.BuiltIn name)
-          | name `elem` ["Int","Float","Bool","String"] ->
+          | name `elem` ["Int","Float","Bool","String","Char"] ->
               x
 
       T.Type name

--- a/src/Reporting/Error/Canonicalize.hs
+++ b/src/Reporting/Error/Canonicalize.hs
@@ -244,7 +244,7 @@ toReport localizer err =
                 , indent 4 (RenderType.toDoc localizer localType)
                 , text ("The types of values that can flow through " ++ boundPort ++ "s include:")
                 , indent 4 $ Help.reflowParagraph $
-                    "Ints, Floats, Bools, Strings, Maybes, Lists, Arrays,\
+                    "Ints, Floats, Bools, Strings, Chars, Maybes, Lists, Arrays,\
                     \ Tuples, Json.Values, and concrete records."
                 ]
             )

--- a/tests/test-files/good-expected-js/Declarations/Ports.elm.js
+++ b/tests/test-files/good-expected-js/Declarations/Ports.elm.js
@@ -12,6 +12,11 @@ Elm.Main.make = function (_elm) {
       });
    },
    _U.list([{name: "Tom",age: 42}]));
+   var letter = Elm.Native.Port.make(_elm).outbound("letter",
+   function (v) {
+      return v;
+   },
+   _U.chr("E"));
    var time = Elm.Native.Port.make(_elm).outbound("time",
    function (v) {
       return v;
@@ -50,6 +55,12 @@ Elm.Main.make = function (_elm) {
    "Int",
    function (v) {
       return typeof v === "number" ? v : _U.badPort("a number",v);
+   });
+   var character = Elm.Native.Port.make(_elm).inbound("character",
+   "Char",
+   function (v) {
+      return typeof v === "string" || typeof v === "object" && v instanceof String ? _U.chr(v) : _U.badPort("a string",
+      v);
    });
    var userID = Elm.Native.Port.make(_elm).inbound("userID",
    "String",

--- a/tests/test-files/good/Declarations/Ports.elm
+++ b/tests/test-files/good/Declarations/Ports.elm
@@ -1,6 +1,7 @@
 
 -- incoming
 port userID : String
+port character : Char
 port number : Int
 port tuple : (Float,Bool)
 port array : List Int
@@ -11,10 +12,13 @@ port fortyTwo : Int
 port fortyTwo =
     42
 
-
 port time : Float
 port time =
     3.14
+
+port letter : Char
+port letter =
+    'E'
 
 port students : List { name:String, age:Int }
 port students =


### PR DESCRIPTION
Hi,

I’ve noticed that you can’t pass `Char` values through inbound and outbound ports. I don’t know if there is a good reason for that, so I thought I’d try to add support for passing chars.

The way it works is as follows:

* for inbound ports, a value given from JS is wrapped with `Utils.chr`
* for outbound ports the value is just passed as is—as a `String` object tagged with `isChar`. This may be not ideal, as the resulting object won’t be an `instanceof String`. So maybe it would be better to call `toString` on it.

In the inbound case, there is no check for whether only a single-char string was passed. Do you think we should check it too? I suppose it should be easy to add.

I also noticed that we’re fairly permissive when it comes to number values. For instance, you can pass a non-integer number to a port of type `Int` and no error is raised. I’ll be happy to fix that, I just wasn’t sure if it’s intentional or not.

I’ll appreciate any feedback on the PR :) Thanks!
