### PR TITLE
Disallow non-integer numbers to be passed to Int ports

### DIFF
--- a/tests/test-files/good-expected-js/Declarations/Ports.elm.js
+++ b/tests/test-files/good-expected-js/Declarations/Ports.elm.js
@@ -31,7 +31,7 @@ Elm.Main.make = function (_elm) {
                                                              v.y)} : _U.badPort("an object with fields `x`, `y`",v);
    });
    var array = Elm.Native.Port.make(_elm).inbound("array",
-   "List Int",
+   "List Float",
    function (v) {
       return typeof v === "object" && v instanceof Array ? Elm.Native.List.make(_elm).fromArray(v.map(function (v) {
          return typeof v === "number" ? v : _U.badPort("a number",v);
@@ -49,7 +49,8 @@ Elm.Main.make = function (_elm) {
    var number = Elm.Native.Port.make(_elm).inbound("number",
    "Int",
    function (v) {
-      return typeof v === "number" ? v : _U.badPort("a number",v);
+      return typeof v === "number" && isFinite(v) && Math.floor(v) === v ? v : _U.badPort("an integer",
+      v);
    });
    var userID = Elm.Native.Port.make(_elm).inbound("userID",
    "String",

--- a/tests/test-files/good/Declarations/Ports.elm
+++ b/tests/test-files/good/Declarations/Ports.elm
@@ -3,7 +3,7 @@
 port userID : String
 port number : Int
 port tuple : (Float,Bool)
-port array : List Int
+port array : List Float
 port record : { x:Float, y:Float }
 
 -- outgoing


### PR DESCRIPTION
This should solve the issue I reported in #1162.

It adds additional checks performed when accepting a value to an incoming port of type `Int`.

The check is based on a polyfill for [Number.isInteger](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/isInteger). NaN and infinite values are handled correctly (and not accepted.

The output for the [test case](https://gist.github.com/jdudek/d89c52f12b10f732d912) I posted looks as follows:

```
Port Error:

    Regarding the port named 'int' with type:
    
        Int
    
    You just sent the value:
    
        3.14
    
    but it cannot be converted to the necessary type.
    Runtime error when sending values through a port.
    
    Expecting an integer but was given 3.14

Open the developer console for more details.
```