### PR TITLE
Correctly parse Foo.Bar.record.field

### DIFF
--- a/src/Parse/Helpers.hs
+++ b/src/Parse/Helpers.hs
@@ -295,8 +295,8 @@ accessible exprParser =
                 end <- getMyPosition
                 return . A.at start end $
                     case rootExpr of
-                      E.Var (Variable.Raw name@(c:_))
-                        | isUpper c ->
+                      E.Var (Variable.Raw name)
+                        | isUpper . head . last . Help.splitDots $ name ->
                             E.rawVar (name ++ '.' : v)
                       _ ->
                         E.Access annotatedRootExpr v


### PR DESCRIPTION
Allow access to fields of qualified records