### PR TITLE
Allow upper case names for now

### DIFF
--- a/src/Elm/Package.hs
+++ b/src/Elm/Package.hs
@@ -74,9 +74,6 @@ validate str =
   else if elem '_' str then
       Left "Underscores are not allowed in package names."
 
-  else if any Char.isUpper str then
-      Left "Upper case characters are not allowed in package names."
-
   else if not (Char.isLetter (head str)) then
       Left "Package names must start with a letter."
 


### PR DESCRIPTION
Instead it makes sense to make package.elm-lang.org disallow publishing
of packages with capital letters. This way things keep working for 0.15
people.