### PR TITLE
Friendlier missingBranchesMessage

### DIFF
--- a/src/Reporting/Error/Pattern.hs
+++ b/src/Reporting/Error/Pattern.hs
@@ -85,8 +85,8 @@ toCaseMessage =
 missingBranchesMessage :: Int -> String
 missingBranchesMessage numUnhandled =
   if numUnhandled == 1 then
-    "Add a branch to cover this pattern!"
+    "Add a branch to cover this pattern."
 
   else
-    "Add branches to cover each of these patterns!"
+    "Add branches to cover each of these patterns."
 


### PR DESCRIPTION
I think the "!" makes it read less friendly that it could be. This is also more consistent with other messages in this file.