### PR TITLE
Tests for #951: Allow qualified names in case patterns

### DIFF
--- a/src/Parse/Pattern.hs
+++ b/src/Parse/Pattern.hs
@@ -98,7 +98,8 @@ patternConstructor =
         case v of
           "True"  -> return $ P.Literal (L.Boolean True)
           "False" -> return $ P.Literal (L.Boolean False)
-          _       -> P.Data (Var.Raw v) <$> spacePrefix term
+          _       -> P.Data (Var.Raw v) <$>
+                       spacePrefix (patternConstructor <|> term)
 
 
 expr :: IParser P.RawPattern

--- a/tests/Test/Compiler.hs
+++ b/tests/Test/Compiler.hs
@@ -81,6 +81,9 @@ essentialInterfaces =
             ("crash", Type.Lambda (Type.Var "String") (Type.Var "a"))
           ]
       )
+    , (ModuleName.inCore ["Foobar"],
+        compileStringToInterface "module Foobar where\ntype Foobar = Foo | Bar"
+      )
     ]
 
 
@@ -109,6 +112,19 @@ compileString filePath source =
         concatMap (Compiler.errorToString dealiaser filePath source) errors
   in
       either (Left . formatErrors) Right result
+
+
+compileStringToInterface :: String -> Module.Interface
+compileStringToInterface source =
+  let dependentModuleNames =
+        []
+      context =
+        Compiler.Context Package.coreName True False dependentModuleNames
+      (_dealiaser, _warnings, result) =
+        Compiler.compile context source Map.empty
+      (Right (Compiler.Result _ interface _)) = result
+  in
+      interface
 
 
 readFileOrErrorStr :: FilePath -> IO String

--- a/tests/test-files/good-expected-js/Cases/QualifiedTypeConstructor.elm.js
+++ b/tests/test-files/good-expected-js/Cases/QualifiedTypeConstructor.elm.js
@@ -1,0 +1,11 @@
+Elm.Main = Elm.Main || {};
+Elm.Main.make = function (_elm) {
+   "use strict";
+   _elm.Main = _elm.Main || {};
+   if (_elm.Main.values) return _elm.Main.values;
+   var _U = Elm.Native.Utils.make(_elm),$Foobar = Elm.Foobar.make(_elm);
+   var _op = {};
+   var count = function (action) {    var _p0 = action;if (_p0._0.ctor === "Foo") {    return 0;} else {    return 1;}};
+   var Action = function (a) {    return {ctor: "Action",_0: a};};
+   return _elm.Main.values = {_op: _op,Action: Action,count: count};
+};

--- a/tests/test-files/good/Cases/QualifiedTypeConstructor.elm
+++ b/tests/test-files/good/Cases/QualifiedTypeConstructor.elm
@@ -1,0 +1,8 @@
+import Foobar exposing (..)
+
+type Action = Action Foobar
+
+count action =
+  case action of
+    Action Foobar.Foo -> 0
+    Action Foobar.Bar -> 1


### PR DESCRIPTION
I wrote a test for the pull request (#1167) submitted by @sgillis.

I’m not sure if running compiler to get the interface is the best solution… I tried the alternative, i.e. with awfully lot of effort I was able to construct the interface as AST. It looked more or less like this: https://gist.github.com/jdudek/1b6d0a17c80ca791563d I felt it was less readable, so I submitted this version.

I also wasn’t sure if cheating by incomplete pattern match for compilation result is OK… perhaps there is a better way.

Anyway, I hope it will be useful :)

