### PR TITLE
Add custom error message if tab character is found in parsing.

### DIFF
--- a/src/Parse/Helpers.hs
+++ b/src/Parse/Helpers.hs
@@ -346,7 +346,7 @@ badWhiteSpaceMessage =
 
 failIfTabFound :: IParser ()
 failIfTabFound =
-  do  foundTab <- option False (lookAhead (char '\t') >> return True)
+  do  foundTab <- option False (lookAhead (char '\t') >> return True) <?> Syntax.tab
       if foundTab
         then fail tabsErrorMessage
         else return ()

--- a/src/Parse/Helpers.hs
+++ b/src/Parse/Helpers.hs
@@ -348,13 +348,8 @@ failIfTabFound :: IParser ()
 failIfTabFound =
   do  foundTab <- option False (lookAhead (char '\t') >> return True) <?> Syntax.tab
       if foundTab
-        then fail tabsErrorMessage
+        then fail Syntax.tab
         else return ()
-
-
-tabsErrorMessage :: String
-tabsErrorMessage =
-  "A tab character was found, but all whitespace (including indentation) must be spaces not tabs."
 
 
 -- Just eats whitespace until the next meaningful character.

--- a/src/Parse/Helpers.hs
+++ b/src/Parse/Helpers.hs
@@ -327,7 +327,9 @@ spaces =
 
 forcedWS :: IParser String
 forcedWS =
-  do  ws <- many1 (spaces <|> newline)
+  do  failIfTabFound
+      ws <- many1 (spaces <|> newline)
+      failIfTabFound
       column <- sourceColumn <$> getPosition
       if column == 1
         then fail badWhiteSpaceMessage
@@ -340,6 +342,19 @@ badWhiteSpaceMessage =
   ++ "\n"
   ++ "You are either missing some stuff in the declaration above or just need to add\n"
   ++ "some spaces here:"
+
+
+failIfTabFound :: IParser ()
+failIfTabFound =
+  do  foundTab <- option False (lookAhead (char '\t') >> return True)
+      if foundTab
+        then fail tabsErrorMessage
+        else return ()
+
+
+tabsErrorMessage :: String
+tabsErrorMessage =
+  "A tab character was found, but all whitespace (including indentation) must be spaces not tabs."
 
 
 -- Just eats whitespace until the next meaningful character.

--- a/src/Reporting/Error/Syntax.hs
+++ b/src/Reporting/Error/Syntax.hs
@@ -228,6 +228,10 @@ whitespace :: String
 whitespace = "WHITESPACE"
 
 
+tab :: String
+tab = "TAB"
+
+
 keyword :: String -> String
 keyword kwd =
   "KEYWORD=" ++ kwd
@@ -263,7 +267,12 @@ parseErrorReport messages =
               else
                   msg
           in
-            hint { _expected = Set.insert msg' (_expected hint) }
+            if msg == tab then
+              -- Our parser looks for tab so it can throw a custom tab error message.
+              -- Exclude tabs from the list of expected tokens so that no one thinks they are supported.
+              hint
+            else
+              hint { _expected = Set.insert msg' (_expected hint) }
 
         Parsec.Message msg ->
             hint { _messages = msg : _messages hint }

--- a/src/Reporting/Error/Syntax.hs
+++ b/src/Reporting/Error/Syntax.hs
@@ -237,10 +237,18 @@ keyword kwd =
   "KEYWORD=" ++ kwd
 
 
-unkeyword :: String -> Maybe String
-unkeyword message =
+data SpecialMessage
+  = MsgKeyword String
+  | MsgTab
+
+
+extractSpecialMessage :: String -> Maybe SpecialMessage
+extractSpecialMessage message =
   if List.isPrefixOf "KEYWORD=" message then
-      Just (drop (length "KEYWORD=") message)
+      Just $ MsgKeyword (drop (length "KEYWORD=") message)
+
+  else if tab == message then
+      Just MsgTab
 
   else
       Nothing
@@ -283,10 +291,15 @@ parseErrorReport messages =
     (preHint, maybePost) =
       case msgs of
         [msg] ->
-            case unkeyword msg of
-              Just kwd ->
+            case extractSpecialMessage msg of
+              Just (MsgKeyword kwd) ->
                   ( "It looks like the keyword `" ++ kwd ++ "` is being used as a variable."
                   , Just "Rename it to something else."
+                  )
+
+              Just MsgTab ->
+                  ( "A tab character was found, but all whitespace (including indentation) must be spaces not tabs."
+                  , Just "I am looking for spaces, not tabs."
                   )
 
               Nothing ->


### PR DESCRIPTION
Given this file:
```elm
list =
<tab>[
<tab><tab>1
<tab>]
```

Elm will now give this error message:
```
-- SYNTAX PROBLEM -------------------------- TabIndent.elm

A tab character was found, but all whitespace (including indentation) must be
spaces not tabs.

3│ 	[
   ^
I am looking for one of the following things:

    whitespace

```