### PR TITLE
Fix unsafe list patterns in error reporting.

### DIFF
--- a/elm-compiler.cabal
+++ b/elm-compiler.cabal
@@ -146,6 +146,7 @@ Library
         parsec >= 3.1.1 && < 3.5,
         pretty >= 1.0 && < 2.0,
         process,
+        semigroups >=0.18 && <0.19,
         text >= 1 && < 2,
         union-find >= 0.2 && < 0.3,
         wl-pprint
@@ -218,6 +219,7 @@ Test-Suite compiler-tests
         parsec >= 3.1.1 && < 3.5,
         pretty >= 1.0 && < 2.0,
         process,
+        semigroups >=0.18 && <0.19,
         text >= 1 && < 2,
         union-find >= 0.2 && < 0.3,
         wl-pprint

--- a/src/Reporting/Error/Helpers.hs
+++ b/src/Reporting/Error/Helpers.hs
@@ -11,6 +11,7 @@ module Reporting.Error.Helpers
 import Data.Function (on)
 import qualified Data.Char as Char
 import qualified Data.List as List
+import qualified Data.List.NonEmpty as NEL
 import qualified Data.Map as Map
 import qualified Data.Set as Set
 import qualified Text.EditDistance as Dist
@@ -69,17 +70,17 @@ reflowParagraph paragraph =
   fillSep (map text (words paragraph))
 
 
-commaSep :: [String] -> String
+commaSep :: NEL.NonEmpty String -> String
 commaSep tokens =
   case tokens of
-    [token] ->
+    token NEL.:| [] ->
       " " ++ token
 
-    [token1,token2] ->
+    token1 NEL.:| [token2] ->
       " " ++ token1 ++ " and " ++ token2
 
     _ ->
-      " " ++ List.intercalate ", " (init tokens) ++ ", and " ++ last tokens
+      " " ++ List.intercalate ", " (NEL.init tokens) ++ ", and " ++ NEL.last tokens
 
 
 capitalize :: String -> String


### PR DESCRIPTION
Hi.

This fixes up some unsafe pattern matching by using non empty lists where appropriate.

Please let me know if this is welcome.

Cheers!