### PR TITLE
Don't show the same unhandled pattern several times in error message

### DIFF
--- a/src/Reporting/Error/Pattern.hs
+++ b/src/Reporting/Error/Pattern.hs
@@ -2,6 +2,7 @@
 module Reporting.Error.Pattern where
 
 import Text.PrettyPrint.ANSI.Leijen (text)
+import Data.List (nub)
 
 import qualified Nitpick.Pattern as Pattern
 import qualified Reporting.Error.Helpers as Help
@@ -61,7 +62,7 @@ unhandledError :: [Pattern.Pattern] -> String -> String
 unhandledError unhandledPatterns relevantMessage =
   let
     (visiblePatterns, rest) =
-      splitAt 4 unhandledPatterns
+      splitAt 4 (nub unhandledPatterns)
 
     patternList =
         map (Pattern.toString False) visiblePatterns


### PR DESCRIPTION
The current compiler, when given this program:
```elm
type A = B | C | D | E

f x y =
    case (x, y) of
        (B, _) -> 0
        (C, False) -> 0
        (D, False) -> 0
```
complains:
```
You need to account for the following values:

    (Main.C, True)
    (Main.C, True)
    (Main.D, True)
    (Main.D, True)
    ...

Add branches to cover each of these patterns!
```
It's very weird that it mentions each of the patterns `(Main.C, True)` and `(Main.D, True)` twice. Moreover, because of that, information about the *also* missing pattern `(Main.E, _)` is hidden away from the user, inside the cut off "`...`".

Far better would be if the list of unhandled patterns would first be cleaned up, eliminating duplicates, so that then there would be room for showing additional interesting information.

That's what this pull request does, with a two lines change.

@evancz?