### PR TITLE
Make Travis badge reflect master branch status

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 Learn about the Elm programming language at [elm-lang.org](http://elm-lang.org/).
 
-[![Build Status](https://travis-ci.org/elm-lang/elm-compiler.svg)](https://travis-ci.org/elm-lang/elm-compiler)
+[![Build Status](https://travis-ci.org/elm-lang/elm-compiler.svg?branch=master)](https://travis-ci.org/elm-lang/elm-compiler)
 
 ## Install
 


### PR DESCRIPTION
Without a branch specifier, the Travis build status badge at the top of the README show the status of the latest build, which is not very useful and may give a wrong impression of brokenness.

(PR requested by @jvoigtlaender in https://github.com/elm-lang/core/pull/515) 