### PR TITLE
Don't allow duplicate fields in record types or aliases

### DIFF
--- a/tests/test-files/bad/RecordAliasDuplicateFields.elm
+++ b/tests/test-files/bad/RecordAliasDuplicateFields.elm
@@ -1,0 +1,5 @@
+
+type alias Bad =
+  { foo : String
+  , foo : Int
+  }

--- a/tests/test-files/bad/RecordTypeDuplicateFields.elm
+++ b/tests/test-files/bad/RecordTypeDuplicateFields.elm
@@ -1,0 +1,3 @@
+
+f : { foo : String , foo : Int } -> Int
+f r = r.foo


### PR DESCRIPTION
Fixes #1323 by disallowing duplicate fields in type aliases of records [EDIT: and in type annotations]. Includes ~~a test~~ two tests.

Evan, I realize this is something you could fix fairly quickly and in your preferred style. But this was an informative exercise for me, and I thought I'd at least give you the option of merging.