### PR TITLE
Constrain language-ecmascript package version to make tests pass

### DIFF
--- a/elm-compiler.cabal
+++ b/elm-compiler.cabal
@@ -140,7 +140,7 @@ Library
         edit-distance >= 0.2 && < 0.3,
         filepath >= 1 && < 2.0,
         indents >= 0.3 && < 0.4,
-        language-ecmascript >= 0.15 && < 0.18,
+        language-ecmascript >= 0.15 && < 0.17.1,
         language-glsl >= 0.0.2 && < 0.3,
         mtl >= 2.2 && < 3,
         parsec >= 3.1.1 && < 3.5,


### PR DESCRIPTION
Fixes the problem observed in https://github.com/elm-lang/elm-compiler/issues/1320. Note the "All checks have passed" below here.