### PR TITLE
Create issue template to try to reduce duplicates

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,0 +1,11 @@
+Thank you for reporting an issue with Elm! Before submitting, please make sure it's not a commonly reported issue:
+
+* If you're getting a runtime error, make sure you don't have any recursively defined values (see #873).
+* If you're having trouble with type annotations in a let-expression, see #1214.
+* If the issue relates to the core libraries and not the language, please open an issue in that repo [https://github.com/elm-lang/core/issues/new].
+* If you've encountered an unhelpful error message, report it to the error message catalog [https://github.com/elm-lang/error-message-catalog/issues/new]
+
+If you still don't see your bug or concern, delete this message and write up a report that satisfies [this checklist](https://github.com/process-bot/contribution-checklist/blob/master/participation.md).
+
+Here is [what to expect next](https://github.com/process-bot/contribution-checklist/blob/master/expectations.md), and if anyone wants to comment, please keep [these things](https://github.com/process-bot/contribution-checklist/blob/master/participation.md) in mind.
+


### PR DESCRIPTION
New issues will automatically be pre-populated with the contents of this file. This should hopefully cut down the volume of issues that we're seeing with the same bugs.