### PR TITLE
Disallow union types containing unused type variables

### DIFF
--- a/src/Reporting/Error/Helpers.hs
+++ b/src/Reporting/Error/Helpers.hs
@@ -72,14 +72,17 @@ reflowParagraph paragraph =
 commaSep :: [String] -> String
 commaSep tokens =
   case tokens of
-    [token] ->
-      " " ++ token
+    [] ->
+      ""
 
-    [token1,token2] ->
-      " " ++ token1 ++ " and " ++ token2
+    [token] ->
+      token
+
+    [token1, token2] ->
+     token1 ++ " and " ++ token2
 
     _ ->
-      " " ++ List.intercalate ", " (init tokens) ++ ", and " ++ last tokens
+      List.intercalate ", " (init tokens) ++ ", and " ++ last tokens
 
 
 capitalize :: String -> String

--- a/src/Reporting/Error/Syntax.hs
+++ b/src/Reporting/Error/Syntax.hs
@@ -251,7 +251,7 @@ unboundTypeVars declKind typeName givenVars unboundVars =
   Report.report
     "UNBOUND TYPE VARIABLES"
     Nothing
-    ( Help.capitalize declKind ++ " `" ++ typeName ++ "` must declare its use of type variable"
+    ( Help.capitalize declKind ++ " `" ++ typeName ++ "` must declare its use of type variables: "
       ++ Help.commaSep unboundVars
     )
     ( Help.stack

--- a/src/Reporting/Error/Syntax.hs
+++ b/src/Reporting/Error/Syntax.hs
@@ -34,7 +34,9 @@ data Error
     | DuplicateDefinition String
     | UnboundTypeVarsInUnion String [String] [String]
     | UnboundTypeVarsInAlias String [String] [String]
+    | UnusedTypeVarsInUnion String [String] [String]
     | UnusedTypeVarsInAlias String [String] [String]
+    | MessyTypeVarsInUnion String [String] [String] [String]
     | MessyTypeVarsInAlias String [String] [String] [String]
 
 
@@ -231,38 +233,17 @@ toReport _localizer err =
     UnboundTypeVarsInAlias typeName givenVars unbound ->
         unboundTypeVars "type alias" typeName givenVars unbound
 
+    UnusedTypeVarsInUnion typeName givenVars unused ->
+        unusedTypeVars "type" typeName givenVars unused
+
     UnusedTypeVarsInAlias typeName givenVars unused ->
-        Report.report
-          "UNUSED TYPE VARIABLES"
-          Nothing
-          ( "Type alias `" ++ typeName ++ "` cannot have unused type variables: "
-            ++ Help.commaSep unused
-          )
-          ( Help.stack
-              [ text "You probably need to change the declaration like this:"
-              , dullyellow $ hsep $
-                  map text ("type" : "alias" : typeName : filter (`notElem` unused) givenVars ++ ["=", "..."])
-              ]
-          )
+        unusedTypeVars "type alias" typeName givenVars unused
+
+    MessyTypeVarsInUnion typeName givenVars unused unbound ->
+        messyTypeVars "type" typeName givenVars unused unbound
 
     MessyTypeVarsInAlias typeName givenVars unused unbound ->
-        Report.report
-          "TYPE VARIABLE PROBLEMS"
-          Nothing
-          ( "Type alias `" ++ typeName ++ "` has some problems with type variables."
-          )
-          ( Help.stack
-              [ Help.reflowParagraph $
-                  "The declaration says it uses certain type variables ("
-                  ++ Help.commaSep unused ++ ") but they do not appear in the aliased type. "
-                  ++ "Furthermore, the aliased type says it uses type variables ("
-                  ++ Help.commaSep unbound
-                  ++ ") that do not appear in the declaration."
-              , text "You probably need to change the declaration like this:"
-              , dullyellow $ hsep $
-                  map text ("type" : "alias" : typeName : filter (`notElem` unused) givenVars ++ unbound ++ ["=", "..."])
-              ]
-          )
+        messyTypeVars "type alias" typeName givenVars unused unbound
 
 
 unboundTypeVars :: String -> String -> [String] -> [String] -> Report.Report
@@ -286,6 +267,46 @@ unboundTypeVars declKind typeName givenVars unboundVars =
         ]
     )
 
+
+unusedTypeVars :: String -> String -> [String] -> [String] -> Report.Report
+unusedTypeVars declKind typeName givenVars unused =
+  Report.report
+    "UNUSED TYPE VARIABLES"
+    Nothing
+    ( Help.capitalize declKind ++ " `" ++ typeName ++ "` cannot have unused type variables: "
+      ++ Help.commaSep unused
+    )
+    ( Help.stack
+        [ text "You probably need to change the declaration like this:"
+        , dullyellow $ hsep $
+            map text $ words declKind ++ typeName : filter (`notElem` unused) givenVars ++ ["=", "..."]
+        ]
+    )
+
+messyTypeVars :: String -> String -> [String] -> [String] -> [String] -> Report.Report
+messyTypeVars declKind typeName givenVars unused unbound =
+  Report.report
+    "TYPE VARIABLE PROBLEMS"
+    Nothing
+    ( Help.capitalize declKind ++ " `" ++ typeName ++ "` has some problems with type variables."
+    )
+    ( Help.stack
+        [ Help.reflowParagraph $
+            "The declaration says it uses certain type variables ("
+            ++ Help.commaSep unused ++ ") but they do not appear in the" ++ typeDescr ++ "type. "
+            ++ "Furthermore, the" ++ typeDescr ++ "type says it uses type variables ("
+            ++ Help.commaSep unbound ++ ") that do not appear in the declaration."
+        , text "You probably need to change the declaration like this:"
+        , dullyellow $ hsep $
+            map text $ words declKind ++ typeName : filter (`notElem` unused) givenVars ++ unbound ++ ["=", "..."]
+        ]
+    )
+  where
+    typeDescr =
+      if declKind == "type alias" then
+        " aliased "
+      else
+        " defined "
 
 
 -- TAGGING PARSE ERRORS

--- a/src/Validate.hs
+++ b/src/Validate.hs
@@ -630,12 +630,20 @@ detectDuplicates tag names =
 checkTypeVarsInUnion :: A.Commented (D.Union Type.Raw) -> Result wrn ()
 checkTypeVarsInUnion (A.A (region,_) (D.Type name boundVars ctors)) =
   case diff boundVars (concatMap freeVars (concatMap snd ctors)) of
-    (_, []) ->
+    ([], []) ->
         return ()
 
-    (_, unbound) ->
+    ([], unbound) ->
         Result.throw region
           (Error.UnboundTypeVarsInUnion name boundVars unbound)
+
+    (unused, []) ->
+        Result.throw region
+          (Error.UnusedTypeVarsInUnion name boundVars unused)
+
+    (unused, unbound) ->
+        Result.throw region
+          (Error.MessyTypeVarsInUnion name boundVars unused unbound)
 
 
 checkTypeVarsInAlias :: A.Commented (D.Alias Type.Raw) -> Result wrn ()

--- a/tests/test-files/bad/UnusedTypeVarInUnion.elm
+++ b/tests/test-files/bad/UnusedTypeVarInUnion.elm
@@ -1,0 +1,1 @@
+type A a = A


### PR DESCRIPTION
The following is rightly valid Elm:
```elm
type Tree = Node | Leaf Int Tree Tree
```
The following is accepted by the 0.16 compiler but shouldn't be:
```elm
type Tree a = Node | Leaf Int Tree Tree
```
It has an unused type variable, and this should be rejected as it is for type aliases. The code to detect and report this is fairly mechanical, following the lead from aliases, and extracting out functions where appropriate.

I also improved the formatting of an error message and a related helper function, as described in the second commit message.

There's a simple test file that I added, and I was also able to get the patched compiler running to verify that the bad code is caught and has a nice message.

Rebased onto all the 0.17 changes so this should merge without conflicts.
