### PR TITLE
Validate record types to have no duplicate fields.

### DIFF
--- a/src/AST/Expression/Valid.hs
+++ b/src/AST/Expression/Valid.hs
@@ -28,3 +28,7 @@ getPattern :: Def -> Pattern.Raw
 getPattern (Def pattern _ _) =
   pattern
 
+
+getAnnotation :: Def -> Maybe Type.Raw
+getAnnotation (Def _ _ annotation) =
+  annotation

--- a/src/Reporting/Error/Syntax.hs
+++ b/src/Reporting/Error/Syntax.hs
@@ -28,7 +28,8 @@ data Error
 
     | InfixDuplicate String
     | TypeWithoutDefinition String
-    | DuplicateFieldName String
+    | DuplicateFieldNameInRecord String
+    | DuplicateFieldNameInRecordType String
     | DuplicateValueDeclaration String
     | DuplicateTypeDeclaration String
     | DuplicateDefinition String
@@ -184,11 +185,18 @@ toReport _localizer err =
               ++ "    " ++ valueName ++ " = 42"
           )
 
-    DuplicateFieldName name ->
+    DuplicateFieldNameInRecord name ->
         Report.report
           "DUPLICATE FIELD"
           Nothing
           ("This record has more than one field named `" ++ name ++ "`.")
+          (text "There can only be one. Do some renaming to make sure the names are distinct!")
+
+    DuplicateFieldNameInRecordType name ->
+        Report.report
+          "DUPLICATE FIELD"
+          Nothing
+          ("This record type has more than one field named `" ++ name ++ "`.")
           (text "There can only be one. Do some renaming to make sure the names are distinct!")
 
     DuplicateValueDeclaration name ->

--- a/tests/test-files/bad/RecordAliasDuplicateFields.elm
+++ b/tests/test-files/bad/RecordAliasDuplicateFields.elm
@@ -1,0 +1,2 @@
+type alias Bad =
+  List { foo : String, foo : Int }

--- a/tests/test-files/bad/RecordTypeDuplicateFields.elm
+++ b/tests/test-files/bad/RecordTypeDuplicateFields.elm
@@ -1,0 +1,3 @@
+
+f : { foo : String , foo : Int } -> Int
+f r = r.foo


### PR DESCRIPTION
This is a redo of #1324: detecting duplicate fields in record types, whether in annotations or aliases. The detection happens during validation, so there's a very nice error and it's possible to get more than one at a time.

Example message:

```
-- DUPLICATE FIELD ---------------------------------------------------- test.elm

This record type has more than one field named `foo`.

9│ g : List { foo : String, foo : Int } -> Int
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^
There can only be one. Do some renaming to make sure the names are distinct!
```

Notice that it detected the duplicate even when nested in a list in a function, and also provides the exact location. This also works for aliases:

```
23│ type alias Foo = List { foo : String, foo : Int } -> Int
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

The implementation is adding another value constructor to `Syntax.Error` an detecting it in `Validate`. As we've seen, we need to recursively traverse raw types to ensure there are no invalid records hiding.

Adds two tests. Renames the value constructor for record _values_ with duplicate fields for matching.
