### PR TITLE
Update Tuple0 reference in Generate.JavaScript.Foreign

### DIFF
--- a/src/Generate/JavaScript/Foreign.hs
+++ b/src/Generate/JavaScript/Foreign.hs
@@ -186,7 +186,7 @@ toMaybe tipe =
 
 toTuple0 :: Opt.Expr
 toTuple0 =
-  to "null" <== [Opt.Var (Var.builtin "_Tuple0")]
+  to "null" <== [Opt.Var (Var.inCore ["Native", "Utils"] "Tuple0")]
 
 
 toTuple :: [T.Canonical] -> Opt.Expr


### PR DESCRIPTION
I found that generating an incoming port with `()` as the incoming type made a reference to a variable `_Tuple0` which doesn't exist because of the new native code generation style in 0.17. I found this line here in the compiler and updated it with @eeue56's help to reference `Tuple0` in Native Utils.

(I'm having difficulty getting Haskell set up at the moment, and will reply back if I find that this change is no good)