### PR TITLE
Fix symbol following line number in error messages

### DIFF
--- a/src/Reporting/Render/Code.hs
+++ b/src/Reporting/Render/Code.hs
@@ -78,7 +78,7 @@ addLineNumber maybeSubRegion width n line =
       if n < 0 then " " else show n
 
     lineNumber =
-      replicate (width - length number) ' ' ++ number ++ "│"
+      replicate (width - length number) ' ' ++ number ++ "|"
 
     spacer (R.Region start end) =
       if R.line start <= n && n <= R.line end then


### PR DESCRIPTION
Reason: At least on some Windows systems, the symbol previously used there does not show up properly when utf8 code page is active.

See https://github.com/elm-lang/elm-compiler/issues/1363.