### PR TITLE
aeson-pretty: use Spaces with confIndent

### DIFF
--- a/src/Elm/Docs.hs
+++ b/src/Elm/Docs.hs
@@ -99,7 +99,7 @@ prettyJson value =
 config :: Json.Config
 config =
     Json.Config
-    { Json.confIndent = 2
+    { Json.confIndent = Json.Spaces 2
     , Json.confCompare = Json.keyOrder keys
     }
   where


### PR DESCRIPTION
Based on https://github.com/informatikr/aeson-pretty/blob/375afe8e/Data/Aeson/Encode/Pretty.hs#L124

Prevents the following error building Elm 0.17.1 with GHC 8.0.1:
```
    • No instance for (Num Json.Indent) arising from the literal ‘2’
    • In the ‘confIndent’ field of a record
      In the expression:
        Json.Config
          {Json.confIndent = 2, Json.confCompare = Json.keyOrder keys}
      In an equation for ‘config’:
          config
            = Json.Config
                {Json.confIndent = 2, Json.confCompare = Json.keyOrder keys}
            where
                keys = ["tag", ....]
```