### PR TITLE
Express unknown qualifier in terms of modules

### DIFF
--- a/src/Reporting/Error/Canonicalize.hs
+++ b/src/Reporting/Error/Canonicalize.hs
@@ -138,7 +138,7 @@ toReport localizer err =
           UnknownQualifier qualifier localName ->
               namingError
                 ("Cannot find " ++ var ++ ".")
-                ( "The qualifier `" ++ qualifier ++ "` is not in scope. "
+                ( "The `" ++ qualifier ++ "` module has not been imported. "
                   ++ Help.maybeYouWant (map (\modul -> modul ++ "." ++ localName) suggestions)
                 )
 

--- a/src/Reporting/Error/Canonicalize.hs
+++ b/src/Reporting/Error/Canonicalize.hs
@@ -138,7 +138,7 @@ toReport localizer err =
           UnknownQualifier qualifier localName ->
               namingError
                 ("Cannot find " ++ var ++ ".")
-                ( "The `" ++ qualifier ++ "` module has not been imported. "
+                ( "No module called `" ++ qualifier ++ "` has been imported. "
                   ++ Help.maybeYouWant (map (\modul -> modul ++ "." ++ localName) suggestions)
                 )
 


### PR DESCRIPTION
This addresses https://github.com/elm-lang/error-message-catalog/issues/129 by framing the error in terms of how to fix it.

### Before

```
-- NAMING ERROR ------------------------------------------------------- form.elm

Cannot find variable `String.length`.

16|         if model.password == "" || String.length model.password < 8 then
                                       ^^^^^^^^^^^^^
The qualifier `String` is not in scope. 

Detected errors in 1 module.   
```

## After
```
-- NAMING ERROR ------------------------------------------------------- form.elm

Cannot find variable `String.length`.

16|         if model.password == "" || String.length model.password < 8 then
                                       ^^^^^^^^^^^^^
No module called `String` has been imported.

Detected errors in 1 module.   
```