### PR TITLE
Compiler benchmarking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,7 @@ cabal-dev
 cabal.sandbox.config
 .DS_Store
 *~
+
+compiler-benchmark/benchmark-projects
+compiler-benchmark/benchmark-results
+compiler-benchmark/benchmark-src

--- a/compiler-benchmark/Benchmark.hs
+++ b/compiler-benchmark/Benchmark.hs
@@ -1,0 +1,129 @@
+module Main where
+
+import Control.Monad (unless, forM_, filterM, void, when)
+import System.Directory (doesDirectoryExist, copyFile, setCurrentDirectory, getCurrentDirectory, createDirectoryIfMissing, getDirectoryContents, removeDirectoryRecursive)
+import System.Exit (ExitCode(ExitSuccess))
+import System.FilePath ((</>))
+import System.Process (rawSystem)
+
+data Repo = Repo 
+    { projectName :: String
+    , path :: FilePath
+    , branch :: String
+    }
+
+-- Version of the Elm compiler that is being used.
+data Version
+    = Gold
+    | Test
+    deriving Show
+
+main :: IO ()
+main = do
+    root <- (</> "compiler-benchmark") <$> getCurrentDirectory
+    inside root $ do
+        -- Elm projects
+        createDirectoryIfMissing True "benchmark-projects"
+        inside "benchmark-projects" $ do
+            todoMvcExists <- doesDirectoryExist "elm-todomvc"
+            unless todoMvcExists . void $
+                git ["clone", "https://github.com/evancz/elm-todomvc", "elm-todomvc"]
+            
+        -- Source 
+        createDirectoryIfMissing True "benchmark-src"
+
+        -- elm-compiler
+        makeSrcRepo "elm-compiler" 
+        inside "benchmark-src/elm-compiler" $ do
+            git [ "checkout", "0.17", "--quiet" ]
+
+        -- elm-package
+        makeSrcRepo "elm-package" 
+        inside "benchmark-src/elm-package" $ do
+            git [ "checkout", "0.17", "--quiet" ]
+
+        -- elm-make
+        makeSrcRepo "elm-make" 
+        inside "benchmark-src/elm-make" $ do
+            git [ "checkout", "0.17", "--quiet" ]
+            cabal ["sandbox", "init"]
+            cabal ["sandbox", "add-source", root </> "benchmark-src" </> "elm-compiler"]
+            cabal ["sandbox", "add-source", root </> "benchmark-src" </> "elm-package"]
+            cabal ["install"]
+
+        createDirectoryIfMissing True "benchmark-results"
+
+        -- Compile each project with the golden versions of elm-compiler, elm-make, etc.
+        projects <- listDirectory "benchmark-projects"
+        forM_ projects (compile Gold)
+
+        -- Use the development version of elm-compiler. By default, use the "master"
+        -- branch of the repo in which benchmarking is being run.
+        inside (root </> "benchmark-src/elm-compiler") $ do
+            hasDevBranch <- successful <$> git ["remote", "show", "dev"]
+            unless hasDevBranch (void $ git ["remote", "add", "dev", root </> ".."])
+            git ["pull", "dev", "master"]
+
+        forM_ projects (compile Test)
+
+        reportResults
+
+-- Compile an Elm project using the Elm compiler.
+compile :: Version -> FilePath -> IO ()
+compile version project = do
+    root <- getCurrentDirectory
+    setCurrentDirectory ("benchmark-projects" </> project) 
+    
+    -- Remove the build artifacts so that the full project is built each
+    -- time we run benchmarking. This ensures that the results of subsequent
+    -- benchmarking runs are comparable.
+    elmStuffExists <- doesDirectoryExist "elm-stuff/build-artifacts"
+    when elmStuffExists (removeDirectoryRecursive "elm-stuff/build-artifacts")
+
+    -- The -p flag turns profiling on.
+    let elmMake = rawSystem (root </> "benchmark-src/elm-make/.cabal-sandbox/bin/elm-make")
+    elmMake ["+RTS", "-p"] 
+
+    -- Profiling should produce a file called elm-make.prof.
+    copyFile "elm-make.prof" (root </> "benchmark-results" </> (project ++ "." ++ show version ++ ".prof"))
+
+    -- reset
+    setCurrentDirectory root
+
+reportResults :: IO ()
+reportResults = putStrLn "results"
+
+-- Fetch and prepare a repository containing some component of the Elm Platform.
+makeSrcRepo :: String -> IO ()
+makeSrcRepo projectName = do
+    root <- getCurrentDirectory
+
+    projectExists <- doesDirectoryExist $ "benchmark-src" </> projectName
+    unless projectExists $ do
+        git [ "clone", "https://github.com/elm-lang/" ++ projectName ++ ".git", "benchmark-src" </> projectName]
+        inside ("benchmark-src" </> projectName) $ do
+            copyFile (root </> "cabal.config.example") "cabal.config"
+
+-- HELPER FUNCTIONS
+
+git :: [String] -> IO ExitCode
+git = rawSystem "git"
+
+cabal :: [String] -> IO ExitCode
+cabal = rawSystem "cabal" 
+
+successful :: ExitCode -> Bool
+successful = (== ExitSuccess)
+
+listDirectory :: FilePath -> IO [FilePath]
+listDirectory dir = filter (\d -> d /= "." && d /= "..")
+    <$> getDirectoryContents dir
+
+-- inside changes into the specified directory, performs some IO action,
+-- and then steps back out into the original directory once the action has been
+-- performed.
+inside :: FilePath -> IO a -> IO () 
+inside dir action = do
+    root <- getCurrentDirectory
+    setCurrentDirectory dir >> action >> setCurrentDirectory root
+

--- a/compiler-benchmark/Benchmark.hs
+++ b/compiler-benchmark/Benchmark.hs
@@ -53,17 +53,17 @@ sources =
     [ Repo 
         { projectName = "elm-make"
         , path = "https://github.com/elm-lang/elm-make.git"
-        , branch = "0.17"
+        , branch = "0.17.1"
         }
     , Repo
         { projectName = "elm-package"
         , path = "https://github.com/elm-lang/elm-package.git"
-        , branch = "0.17"
+        , branch = "0.17.1"
         }
     , Repo
         { projectName = "elm-compiler"
         , path = "https://github.com/elm-lang/elm-compiler.git"
-        , branch = "0.17" 
+        , branch = "0.17.1"
         }
     ]   
 

--- a/compiler-benchmark/Benchmark.hs
+++ b/compiler-benchmark/Benchmark.hs
@@ -124,6 +124,9 @@ main = do
 
         -- Set the parent elm-compiler repo to be compiled into elm-make for
         -- development.
+        -- TODO(justinmanley): Fail with an error if elm-make cannot be
+        -- installed with the dev version of the compiler to prevent it from
+        -- compiling using the stable version twice.
         inDirectory ("benchmark-src" </> "elm-make") $ do
             cabal ["sandbox", "delete-source", srcRoot </> "elm-compiler"]
             cabal ["sandbox", "add-source", root]
@@ -162,6 +165,8 @@ addSources root repos = do
 -- COMPILATION
 
 -- Compile an Elm project using the Elm compiler.
+-- TODO(justinmanley): Compile each project multiple times in order to report
+-- when differences in compilation time are actually statistically significant.
 compile :: Version -> Repo -> IO ()
 compile version project = do
     root <- getCurrentDirectory

--- a/compiler-benchmark/Benchmark.hs
+++ b/compiler-benchmark/Benchmark.hs
@@ -8,7 +8,7 @@ import qualified Data.Text.IO as Text
 import Data.Text as Text (Text, pack, unpack)
 import Data.Foldable (find)
 import Data.Map (Map)
-import Data.Maybe (isJust)
+import Data.Maybe (isJust, maybe)
 import Text.Tabular (Table(Table), Header(Header, Group), Properties(NoLine, SingleLine, DoubleLine))
 import qualified Text.Tabular.AsciiArt as Table
 import qualified Data.Map as Map
@@ -67,6 +67,7 @@ dev =
 costCentreNames :: [Text]
 costCentreNames = map Text.pack
     [ "parsing"
+    , "completeness"
     ]
 
 main :: IO ()
@@ -77,8 +78,11 @@ main = do
         createDirectoryIfMissing True "benchmark-projects"
         inDirectory "benchmark-projects" $ do
             todoMvcExists <- doesDirectoryExist "elm-todomvc"
-            unless todoMvcExists . void $
-                git ["clone", "https://github.com/evancz/elm-todomvc", "elm-todomvc"]
+            unless todoMvcExists . void $ git
+                [ "clone"
+                , "https://github.com/evancz/elm-todomvc"
+                , "elm-todomvc"
+                ]
             
         -- Source 
         createDirectoryIfMissing True "benchmark-src"
@@ -98,8 +102,10 @@ main = do
         inDirectory "benchmark-src/elm-make" $ do
             -- git [ "checkout", "0.17", "--quiet" ]
             cabal ["sandbox", "init"]
-            cabal ["sandbox", "add-source", root </> "benchmark-src" </> "elm-compiler"]
-            cabal ["sandbox", "add-source", root </> "benchmark-src" </> "elm-package"]
+            cabal ["sandbox", "add-source",
+                root </> "benchmark-src" </> "elm-compiler"]
+            cabal ["sandbox", "add-source",
+                root </> "benchmark-src" </> "elm-package"]
             cabal ["install"]
 
         createDirectoryIfMissing True "benchmark-results"
@@ -112,12 +118,32 @@ main = do
         -- branch of the repo in which benchmarking is being run.
         inDirectory (root </> "benchmark-src/elm-compiler") $ do
             hasDevBranch <- successful <$> git ["remote", "show", "dev"]
-            unless hasDevBranch (void $ git ["remote", "add", "dev", root </> ".."])
+            unless hasDevBranch (void $ git ["remote", "add", "dev",
+                root </> ".."])
             git ["pull", "dev", "master"]
 
         forM_ projects (compile Test)
 
         reportResults
+
+-- SETUP
+
+-- Fetch and prepare a repository containing some component of the Elm Platform.
+makeSrcRepo :: String -> IO ()
+makeSrcRepo projectName = do
+    root <- getCurrentDirectory
+
+    projectExists <- doesDirectoryExist $ "benchmark-src" </> projectName
+    unless projectExists $ do
+        git [ "clone"
+            , "https://github.com/elm-lang/" ++ projectName ++ ".git"
+            , "benchmark-src" </> projectName
+            ]
+        inDirectory ("benchmark-src" </> projectName) $ do
+            copyFile (root </> "cabal.config.example") "cabal.config"
+
+
+-- COMPILATION
 
 -- Compile an Elm project using the Elm compiler.
 compile :: Version -> FilePath -> IO ()
@@ -132,14 +158,28 @@ compile version project = do
     when elmStuffExists (removeDirectoryRecursive "elm-stuff/build-artifacts")
 
     -- The -p flag turns profiling on.
-    let elmMake = rawSystem (root </> "benchmark-src/elm-make/.cabal-sandbox/bin/elm-make")
+    let elmMake = rawSystem $ root </> "benchmark-src/elm-make/.cabal-sandbox/bin/elm-make"
     elmMake ["+RTS", "-p"] 
 
     -- Profiling should produce a file called elm-make.prof.
-    copyFile "elm-make.prof" (root </> "benchmark-results" </> (project ++ "." ++ show version ++ ".prof"))
+    copyFile "elm-make.prof" (root 
+        </> "benchmark-results" 
+        </> (project ++ "." ++ show version ++ ".prof"))
 
     -- reset
     setCurrentDirectory root
+    
+
+-- REPORTING
+
+-- CostCentreDiff is used to group the cost centre results from runs of
+-- different compilers.
+data CostCentreDiff = CostCentreDiff
+    { gold :: Maybe CostCentre
+    -- ^ Profiling results for the gold version of the compiler
+    , dev :: Maybe CostCentre
+    -- ^ Profiling results for the dev version of the compiler
+    }
 
 reportResults :: IO ()
 reportResults = do
@@ -151,67 +191,65 @@ reportResults = do
 
     case parseOnly timeAllocProfile goldResults of
         Right goldProfile -> do 
-            goldResults <- reportMissingCostCentres . extractCostCentres $ goldProfile 
+            let goldResults = extractCostCentres goldProfile 
 
             case parseOnly timeAllocProfile devResults of
                 Right devProfile -> do
-                    devResults <- reportMissingCostCentres . extractCostCentres $ devProfile
-                    putStrLn . Table.render unpack id show . reportDiffs $ Map.intersectionWith CostCentreDiff goldResults devResults
-                Left error -> putStrLn $ "Error parsing profiling results from " ++ devFilename ++ ": " ++ error
+                    let devResults = extractCostCentres devProfile
+                    
+                    -- Intersection should have no effect here, since the gold
+                    -- and dev maps are both constructed using costCentreNames.
+                    reportDiffs $ Map.intersectionWith CostCentreDiff
+                        goldResults
+                        devResults
+                Left error -> reportParseError devFilename error 
 
-        Left error -> putStrLn $ "Error parsing profiling results from " ++ goldFilename ++ ": " ++ error
+        Left error -> reportParseError goldFilename error 
 
-data CostCentreDiff = CostCentreDiff
-    { gold :: CostCentre
-    -- ^ Profiling results for the gold version of the compiler
-    , dev :: CostCentre
-    -- ^ Profiling results for the dev version of the compiler
-    }
-
--- Adds a header
---reportDiffs :: Map Text CostCentreDiff -> Table (Header 
-reportDiffs results = Table
-        (Group SingleLine [ Group NoLine $ map Header (Map.keys results) ])
-        (Group DoubleLine [ Group NoLine 
-            [ Header "%time in gold"
-            , Header "%time in dev"
-            ]])
-        (map reportDiff $ Map.elems results)
     where
-        reportDiff :: CostCentreDiff -> [Double]
+        reportParseError :: FilePath -> String -> IO ()
+        reportParseError f errorMsg = putStrLn 
+            $ "Error parsing profiling results from "
+            ++ f
+            ++ ": "
+            ++ errorMsg
+
+-- Report the results of profiling in a nice table.
+reportDiffs :: Map Text CostCentreDiff -> IO ()
+reportDiffs results =
+        putStrLn . Table.render unpack id renderMaybe $ resultsTable
+    where
+        resultsTable :: Table Text String (Maybe Double)
+        resultsTable = Table
+            (Group SingleLine [ Group NoLine $ map Header (Map.keys results) ])
+            (Group DoubleLine [ Group NoLine 
+                [ Header "%time in gold"
+                , Header "%time in dev"
+                ]])
+            (map reportDiff $ Map.elems results)
+
+        renderMaybe :: Show a => Maybe a -> String
+        renderMaybe = maybe "-" show
+
+        reportDiff :: CostCentreDiff -> [Maybe Double]
         reportDiff costCentre = 
-            [ costCentreIndTime . gold $ costCentre
-            , costCentreIndTime . dev $ costCentre
+            [ costCentreIndTime <$> gold costCentre
+            , costCentreIndTime <$> dev costCentre
             ]
 
-reportMissingCostCentres :: Map Text (Maybe CostCentre) -> IO (Map Text CostCentre)
-reportMissingCostCentres results = do
-    let (present, missing) = partition (isJust . snd) $ Map.toList results
-    mapM_ reportMissingCostCentre missing    
-    return $ (Map.mapMaybe id . Map.fromList) present
-    where
-        reportMissingCostCentre :: (Text, Maybe CostCentre) -> IO ()
-        reportMissingCostCentre (name, _) = putStrLn $ "Missing cost centre " ++ unpack name
-    
-
+-- Extract cost centres from the given profiling report.
 extractCostCentres :: TimeAllocProfile -> Map Text (Maybe CostCentre)
-extractCostCentres tree = 
-        Map.fromList $ map (\name -> (name, findCostCentre name)) costCentreNames
+extractCostCentres tree = foldr insertCostCentre Map.empty costCentreNames
     where 
+        insertCostCentre :: Text 
+            -> Map Text (Maybe CostCentre)
+            -> Map Text (Maybe CostCentre)
+        insertCostCentre name = Map.insert name (findCostCentre name)
+
         findCostCentre :: Text -> Maybe CostCentre
         findCostCentre name = find ((== name) . costCentreName)
             $ costCentreNodes (profileCostCentreTree tree)
 
--- Fetch and prepare a repository containing some component of the Elm Platform.
-makeSrcRepo :: String -> IO ()
-makeSrcRepo projectName = do
-    root <- getCurrentDirectory
-
-    projectExists <- doesDirectoryExist $ "benchmark-src" </> projectName
-    unless projectExists $ do
-        git [ "clone", "https://github.com/elm-lang/" ++ projectName ++ ".git", "benchmark-src" </> projectName]
-        inDirectory ("benchmark-src" </> projectName) $ do
-            copyFile (root </> "cabal.config.example") "cabal.config"
 
 -- HELPER FUNCTIONS
 

--- a/compiler-benchmark/README.md
+++ b/compiler-benchmark/README.md
@@ -1,0 +1,15 @@
+Benchmarking the Elm compiler
+=============================
+
+This script can help measure the performance of the Elm compiler. To benchmark
+the compiler, type `cabal run compiler-benchmark` in the directory containing
+`elm-compiler.cabal`. By default, this will download stable versions of
+elm-compiler, elm-make, and elm-package from GitHub, and it will compile a set
+of Elm projects using the stable version of the compiler, and the version of
+the Elm compiler in the enclosing repository.
+
+To update the git branches that should be considered "stable", edit the
+`sources` list at the top of `Benchmark.hs`.
+
+To add a new Elm project to the benchmarking script, edit the `projects` list
+at the top of `Benchmark.hs`.

--- a/compiler-benchmark/cabal.config.example
+++ b/compiler-benchmark/cabal.config.example
@@ -1,0 +1,2 @@
+library-profiling: True
+executable-profiling: True

--- a/elm-compiler.cabal
+++ b/elm-compiler.cabal
@@ -185,6 +185,22 @@ Executable elm
         text >= 1 && < 2,
         process
 
+Executable compiler-benchmark
+    ghc-options:
+        -threaded -O2 -W
+
+    Hs-Source-Dirs:
+        compiler-benchmark
+
+    Main-is:
+        Benchmark.hs
+
+    Build-depends:
+        base >=4.2 && <5,
+        directory >= 1.0 && < 2.0,
+        filepath >= 1 && < 2.0,
+        process
+
 
 Test-Suite compiler-tests
     ghc-options:

--- a/elm-compiler.cabal
+++ b/elm-compiler.cabal
@@ -203,6 +203,7 @@ Executable compiler-benchmark
         filepath >= 1 && < 2.0,
         ghc-time-alloc-prof >= 0.0.0.1 && < 0.0.1,
         process,
+        tabular >= 0.2.2.7 && < 0.3,
         text >= 1.2.1.3 && < 1.2.2
 
 

--- a/elm-compiler.cabal
+++ b/elm-compiler.cabal
@@ -196,10 +196,14 @@ Executable compiler-benchmark
         Benchmark.hs
 
     Build-depends:
-        base >=4.2 && <5,
+        attoparsec >= 0.13.0.2 && < 0.14,
+        base >= 4.2 && <5,
+        containers >= 0.5.6.2 && < 0.6, 
         directory >= 1.0 && < 2.0,
         filepath >= 1 && < 2.0,
-        process
+        ghc-time-alloc-prof >= 0.0.0.1 && < 0.0.1,
+        process,
+        text >= 1.2.1.3 && < 1.2.2
 
 
 Test-Suite compiler-tests

--- a/src/Compile.hs
+++ b/src/Compile.hs
@@ -36,7 +36,7 @@ compile packageName canonicalImports interfaces source =
   do
       -- Parse the source code
       validModule <-
-          Result.format Error.Syntax $
+          Result.format Error.Syntax $ {-# SCC parsing #-}
             Parse.program packageName (getOpTable interfaces) source
 
       -- Canonicalize all variables, pinning down where they came from.
@@ -45,7 +45,7 @@ compile packageName canonicalImports interfaces source =
 
       -- Run type inference on the program.
       types <-
-          Result.from Error.Type $
+          Result.from Error.Type $ {-# SCC type_inference #-}
             TI.infer interfaces canonicalModule
 
       -- One last round of checks
@@ -55,11 +55,11 @@ compile packageName canonicalImports interfaces source =
               Can.toSortedDefs (Module.program (Module.info canonicalModule))
 
       tagDict <-
-        Result.format Error.Pattern $
+        Result.format Error.Pattern $ {-# SCC exhaustiveness #-}
           Nitpick.patternMatches interfaces canonicalModule
 
       -- Do some basic optimizations
-      let optimisedDefs =
+      let optimisedDefs = {-# SCC optimization #-}
             Optimize.optimize tagDict (Module.name canonicalModule) canonicalDefs
 
       -- Add the real list of types


### PR DESCRIPTION
Add a script for measuring how long it takes to compile Elm programs.

See [compiler-benchmark/README.md](https://github.com/justinmanley/elm-compiler/blob/compiler-benchmark/compiler-benchmark/README.md) for usage instructions.

I'd like to get feedback on what additional compilation phases might be useful to track, and if I'm tracking the ones I've chosen in the right way. See [`costCentreNames` in Benchmark.hs](https://github.com/justinmanley/elm-compiler/blob/compiler-benchmark/compiler-benchmark/Benchmark.hs#L88).

Here's an example of the output from running the script:

```
+----------------++------------------------------+
|                || %time in stable %time in dev |
+================++==============================+
| exhaustiveness ||               -         27.5 |
|   optimization ||               -          0.6 |
|        parsing ||               -         53.3 |
| type_inference ||               -         11.1 |
+----------------++------------------------------+
```
(There are no numbers reported for the stable version of the compiler because v0.17.1 does not have `{-# SCC #-}` annotations. This is WAI.)