### PR TITLE
Remove references to `(?)` and `unsafe` in missing patterns hints

### DIFF
--- a/hints/missing-patterns.md
+++ b/hints/missing-patterns.md
@@ -138,5 +138,3 @@ last list =
 ```
 
 This is nice because it lets users know that there might be a failure, so they can recover from it however they want.
-
-**Note:** You can define helpers like [`(?)`](https://github.com/elm-lang/core/issues/216) or [`unsafe`](https://github.com/elm-lang/core/issues/215) to make it easier to work with `Maybe` values a bunch. These helpers are being considered for inclusion in core, but it's not hard to put them in your own code and see if they make things nicer for you.


### PR DESCRIPTION
The corresponding issues (elm-lang/core#216 and elm-lang/core#215) have been
closed.