### PR TITLE
Fix wrong link in port type error

### DIFF
--- a/src/Reporting/Error/Canonicalize.hs
+++ b/src/Reporting/Error/Canonicalize.hs
@@ -254,7 +254,7 @@ toReport localizer err =
             , indent 4 (RenderType.toDoc localizer tipe)
             , Help.reflowParagraph $
                 "But you need to use the particular format described here:\
-                \ <http://guide.elm-lang.org/effect_managers/>"
+                \ <http://guide.elm-lang.org/interop/javascript.html>"
             ]
         )
 


### PR DESCRIPTION
On the mailing list, [someone used a wrong port type and got this error](https://groups.google.com/forum/#!topic/elm-discuss/3ieqkWBPvaE):
```
8| port graphName : String
   ^^^^^^^^^^^^^^^^^^^^^^^
You are saying it should be:

    String

But you need to use the particular format described here:
<http://guide.elm-lang.org/effect_managers/>
```
However, the link http://guide.elm-lang.org/effect_managers/ doesn't describe any particular port type format. The link http://guide.elm-lang.org/interop/javascript.html does.