### PR TITLE
Sanitize dots and stars in github module names for JS

### DIFF
--- a/src/Generate/JavaScript/Variable.hs
+++ b/src/Generate/JavaScript/Variable.hs
@@ -129,10 +129,10 @@ moduleToString :: ModuleName.Canonical -> String
 moduleToString (ModuleName.Canonical (Pkg.Name user project) moduleName) =
   let
     safeUser =
-      map (swap '-' '_') user
+      map (swapAny "-.*" '_') user
 
     safeProject =
-      map (swap '-' '_') project
+      map (swapAny "-.*" '_') project
 
     safeModuleName =
       List.intercalate "_" moduleName
@@ -144,6 +144,9 @@ swap :: Char -> Char -> Char -> Char
 swap from to c =
   if c == from then to else c
 
+swapAny :: [Char] -> Char -> Char -> Char
+swapAny badChars goodChar c =
+  if (c `elem` badChars) then goodChar else c
 
 
 -- SAFE NAMES


### PR DESCRIPTION
Resolves: https://github.com/elm-lang/elm-compiler/issues/1475

Previous bad thing:
```
var _michaelbjames$michaelbjames.com$Main$main = { main: _elm_lang$html$Html$text('Hello, World!') };
```

New good thing:
```
var _michaelbjames$michaelbjames_com$Main$main = { main: _elm_lang$html$Html$text('Hello, World!')
};
```

I'm sure this is not the only place where there's an inconsistency between the existing sanitizations and what ES5 is okay with. In fact, I doubt that just `-.*` is enough. 
* Do you think these swaps should map everything that is not `[a-zA-Z0-9$#_]` to `_`?
* Or should it use ecmascript's [`isValidIdPart :: Char -> Bool`](https://hackage.haskell.org/package/language-ecmascript-0.17/candidate/docs/src/Language-ECMAScript3-Syntax.html#isValidIdPart)
* Can you think of some better grand-plan for ensuring identifiers are valid?