### PR TITLE
Swap unsafes in variable name

### DIFF
--- a/src/Generate/JavaScript/Variable.hs
+++ b/src/Generate/JavaScript/Variable.hs
@@ -134,16 +134,22 @@ getOpsDictName home =
 moduleToString :: ModuleName.Canonical -> String
 moduleToString (ModuleName.Canonical (Pkg.Name user project) moduleName) =
   let
+    unsafeChar = "-."
+
     safeUser =
-      map (swap '-' '_') user
+      map (swapUnsafes unsafeChar '_') user
 
     safeProject =
-      map (swap '-' '_') project
+      map (swapUnsafes unsafeChar '_') project
 
     safeModuleName =
       List.intercalate "_" moduleName
   in
     '_' : safeUser ++ "$" ++ safeProject ++ "$" ++ safeModuleName
+
+swapUnsafes :: [Char] -> Char -> Char -> Char
+swapUnsafes froms to c =
+  if c `List.elem` froms then to else c
 
 
 swap :: Char -> Char -> Char -> Char


### PR DESCRIPTION
Solve https://github.com/elm-lang/elm-compiler/issues/1475 in different way

Ref: https://github.com/elm-lang/elm-compiler/pull/1481

In Github, including elm-lang repos, there are many repos with name having `.` character.
However, like `-` character, `.` makes invalid variable name in javascript.

At least I think, swapping these is more fundamental solution for dot problem.