### PR TITLE
Link directly to #ports section for ports hint

### DIFF
--- a/src/Reporting/Error/Canonicalize.hs
+++ b/src/Reporting/Error/Canonicalize.hs
@@ -266,7 +266,7 @@ toReport localizer err =
             , indent 4 (RenderType.toDoc localizer tipe)
             , Help.reflowParagraph $
                 "But you need to use the particular format described here:\
-                \ <http://guide.elm-lang.org/interop/javascript.html>"
+                \ <http://guide.elm-lang.org/interop/javascript.html#ports>"
             ]
         )
 


### PR DESCRIPTION
Adds `#ports` to the end of the URL in the hint about ports.

https://guide.elm-lang.org/interop/javascript.html#ports takes you straight to the part of the page that explains the format.

**Error message before:**

```
But you need to use the particular format described here:

https://guide.elm-lang.org/interop/javascript.html
```

**Error message after:**

```
But you need to use the particular format described here:

https://guide.elm-lang.org/interop/javascript.html#ports
```