### PR TITLE
Fixes typo in fail message: singe -> single

### DIFF
--- a/src/Parse/Binop.hs
+++ b/src/Parse/Binop.hs
@@ -48,7 +48,7 @@ notReserved =
     [ failOn "=" "The = operator is reserved for defining variables. Maybe you want == instead? Or maybe you are defining a variable, but there is whitespace before it?"
     , failOn "->" "Arrows are reserved for cases and anonymous functions. Maybe you want > or >= instead?"
     , failOn "|" "Vertical bars are reserved for use in union type declarations. Maybe you want || instead?"
-    , failOn ":" "A singe colon is for type annotations. Maybe you want :: instead? Or maybe you are defining a type annotation, but there is whitespace before it?"
+    , failOn ":" "A single colon is for type annotations. Maybe you want :: instead? Or maybe you are defining a type annotation, but there is whitespace before it?"
     ]
 
 


### PR DESCRIPTION
Fixes typo see [error-message-catalog issue 176](https://github.com/elm-lang/error-message-catalog/issues/176)