### PR TITLE
Remove unnecessary > in bad_recursion.md

### DIFF
--- a/hints/bad-recursion.md
+++ b/hints/bad-recursion.md
@@ -53,7 +53,7 @@ type alias Comment =
 type Responses = Responses (List Comment)
 ```
 
-> Some of you may have recently run into this definition in the [hints for recursive aliases](recursive-alias.md)!
+Some of you may have recently run into this definition in the [hints for recursive aliases](recursive-alias.md)!
 
 And from there, you may want to be able to turn all the comments into JSON to send back to your server or to store in your database or whatever. So you will probably write some code like this:
 


### PR DESCRIPTION
This is causing the line show show up indented and gray. Pretty sure you didn't want that!