### PR TITLE
Fix "need N more arguments" error message

### DIFF
--- a/src/Reporting/Error/Type.hs
+++ b/src/Reporting/Error/Type.hs
@@ -774,7 +774,7 @@ reasonToStringHelp reason =
 
     MissingArgs num ->
         go $
-          "It looks like a function needs " <> i2t num <> " more" <> Help.args num <> "."
+          "It looks like a function needs " <> Help.moreArgs num <> "."
 
     BadVar (Just Comparable) _ ->
         go "Only ints, floats, chars, strings, lists, and tuples are comparable."

--- a/src/Reporting/Helpers.hs
+++ b/src/Reporting/Helpers.hs
@@ -8,7 +8,7 @@ module Reporting.Helpers
   , vcat
   -- custom helpers
   , i2t
-  , functionName, args
+  , functionName, args, moreArgs
   , hintLink, stack, reflowParagraph
   , commaSep, capitalize, ordinalize, drawCycle
   , findPotentialTypos, findTypoPairs, vetTypos
@@ -71,6 +71,11 @@ functionName opName =
 args :: Int -> Text
 args n =
   i2t n <> if n == 1 then " argument" else " arguments"
+
+
+moreArgs :: Int -> Text
+moreArgs n =
+  i2t n <> " more" <> if n == 1 then " argument" else " arguments"
 
 
 hintLink :: Text -> Text


### PR DESCRIPTION
When compiling the following file:

```
foo = not || False
```

The given error message contains the line:

```
Hint: It looks like a function needs 1 more1 argument.
```

This mistake was introduced in commit 2feb3573, and only affects git master.