### PR TITLE
Change non-Haddock comments which collide with Haddock comment syntax

### DIFF
--- a/src/Generate/JavaScript/Builder.hs
+++ b/src/Generate/JavaScript/Builder.hs
@@ -106,8 +106,8 @@ data InfixOp
   | OpStrictEq -- ===
   | OpStrictNEq -- !===
   | OpLAnd -- &&
-  | OpLOr -- ||
-  | OpMul -- *
+  | OpLOr -- for ||
+  | OpMul -- for *
   | OpDiv -- /
   | OpMod -- %
   | OpSub -- -
@@ -115,8 +115,8 @@ data InfixOp
   | OpSpRShift -- >>
   | OpZfRShift -- >>>
   | OpBAnd -- &
-  | OpBXor -- ^
-  | OpBOr -- |
+  | OpBXor -- for ^
+  | OpBOr -- for |
   | OpAdd -- +
 
 
@@ -124,15 +124,15 @@ data AssignOp
   = OpAssign -- =
   | OpAssignAdd -- +=
   | OpAssignSub -- -=
-  | OpAssignMul -- *=
+  | OpAssignMul -- for *=
   | OpAssignDiv -- /=
   | OpAssignMod -- %=
   | OpAssignLShift -- <<=
   | OpAssignSpRShift -- >>=
   | OpAssignZfRShift -- >>>=
   | OpAssignBAnd -- &=
-  | OpAssignBXor -- ^=
-  | OpAssignBOr -- |=
+  | OpAssignBXor -- for ^=
+  | OpAssignBOr -- for |=
 
 
 data PrefixOp


### PR DESCRIPTION
I tried building Haddock documentation for elm-compiler (later to find out there is very little currently). 

I noticed the Haddock build failing and the culprit was this file which made reference to the operators `|`, `*`, and `^` in the comments. I padded them so that Haddock builds properly, opening up that possibility to use it more in the future.