### PR TITLE
Expand record update syntax to allow general expressions before the p…

### DIFF
--- a/src/Parse/Primitives.hs
+++ b/src/Parse/Primitives.hs
@@ -3,7 +3,7 @@
 module Parse.Primitives
   ( Parser
   , run, runAt
-  , try, deadend, hint, endOfFile
+  , try, optionMaybe, option, deadend, hint, endOfFile
   , oneOf
   , symbol, underscore, keyword, keywords
   , lowVar, capVar, infixOp
@@ -135,6 +135,26 @@ try :: Parser a -> Parser a
 try parser =
   Parser $ \state cok _ eok eerr ->
     _run parser state cok eerr eok eerr
+
+
+optionMaybe :: Parser a -> Parser (Maybe a)
+optionMaybe parser =
+    -- Similar to 'option' in that this will consume input even if the parser
+    -- fails, so you have to combine this with 'try' if you wish to avoid
+    -- consuming input in the case that the parser fails, eg:
+    -- optionMaybe $ try typeSignature
+    oneOf
+        [ do result <- parser
+             return (Just result)
+        , return Nothing
+        ]
+
+option :: a -> Parser a -> Parser a
+option defaultValue parser =
+    -- Note, this will consume input if 'parser' does whether or not it
+    -- ultimately fails, so if you want to avoid that then combine this
+    -- with 'try'.
+    oneOf [ parser, return defaultValue ]
 
 
 shaderFailure :: Int -> Int -> Text -> Parser a

--- a/tests/test-files/good/Records/UpdateSyntax.elm
+++ b/tests/test-files/good/Records/UpdateSyntax.elm
@@ -1,0 +1,33 @@
+{-
+    A test for allowing an arbitrary expression as the first part of the record
+    update syntax.
+-}
+
+
+type alias SubModel =  { counter : Int, other: Int }
+type alias Model = { subModel : SubModel }
+
+identityModel : Model -> Model
+identityModel model = model
+
+resetSubModel : Model -> SubModel
+resetSubModel model =
+    { model.subModel | counter = 0 , other = 1 }
+
+
+termCall : Model -> Model
+termCall model =
+    { (identityModel model) | subModel = { counter = 1, other = 1} }
+
+functionCall : Model -> Model
+functionCall model =
+    { identityModel model | subModel = { counter = 1, other = 1} }
+
+
+emptyRecord = {}
+
+
+(||) : Bool -> Bool -> Bool
+(||) left right = if left then True else right
+
+checkOrStillWorks = False || True


### PR DESCRIPTION
…ipe. Disallow empty updates such as '{ myRecord | }'.

I have added a test file tests/test-files/good/Records, but not a corresponding one in tests/test-files/good-expected-js/, the reason was based on the fact that on the dev branch the compiler test suite was commented out. I uncommented it locally for testing, but only fixed up the types enough to get it to compile not to produce expected Javascript.