### PR TITLE
fix typo, genarate -> generate

### DIFF
--- a/compiler/src/Compile.hs
+++ b/compiler/src/Compile.hs
@@ -72,7 +72,7 @@ compile flag pkg importDict interfaces source =
         Optimize.optimize annotations canonical
 
       documentation <-
-        genarateDocs flag canonical
+        generateDocs flag canonical
 
       Result.ok $
         Artifacts
@@ -117,8 +117,8 @@ exhaustivenessCheck canonical =
 data DocsFlag = YesDocs | NoDocs
 
 
-genarateDocs :: DocsFlag -> Can.Module -> Result.Result i w Error.Error (Maybe Docs.Module)
-genarateDocs flag modul =
+generateDocs :: DocsFlag -> Can.Module -> Result.Result i w Error.Error (Maybe Docs.Module)
+generateDocs flag modul =
   case flag of
     NoDocs ->
       Result.ok Nothing


### PR DESCRIPTION
looks like @zwilias noticed it first: https://github.com/elm-lang/elm-compiler/commit/28037723ecd0e1ad21ca410a423343761ee1018e#commitcomment-27849371

thanks!